### PR TITLE
Make breakpoint mixin private

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -41,8 +41,8 @@
 	@return oAssetsResolve($asset, o-header);
 }
 
-/// Target both IE8 and modern browsers at the breakpoint
-@mixin oHeaderBreakpoint {
+/// Target both IE8 and modern browsers at the M layout
+@mixin _oHeaderBreakpoint {
 	@include oGridRespondTo(M) {
 		@content;
 	}

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -14,7 +14,7 @@
 }
 
 .o-header--tall {
-	@include oHeaderBreakpoint {
+	@include _oHeaderBreakpoint {
 		min-height: 85px;
 		background-image: linear-gradient(to bottom, transparent 80px, oColorsGetColorFor(o-header-product-brand product-brand, background) 20px);
 	}
@@ -75,7 +75,7 @@
 	white-space: nowrap;
 	vertical-align: top;
 
-	@include oHeaderBreakpoint {
+	@include _oHeaderBreakpoint {
 		font-size: 24px;
 
 		.o-header--tall & {
@@ -112,7 +112,7 @@
 	}
 
 	.o-header--tall & {
-		@include oHeaderBreakpoint {
+		@include _oHeaderBreakpoint {
 			height: 80px;
 
 			.o-header__tagline {
@@ -155,13 +155,14 @@
 }
 
 .o-header__primary__featured {
+	// scss-lint:disable DeclarationOrder
 	display: none;
 
 	img {
 		border: 0;
 	}
 
-	@include oHeaderBreakpoint {
+	@include _oHeaderBreakpoint {
 		display: table-cell;
 	}
 

--- a/src/scss/logo.scss
+++ b/src/scss/logo.scss
@@ -30,13 +30,13 @@
 		vertical-align: top;
 		margin-right: $o-grid-gutter / 2;
 
-		@include oHeaderBreakpoint {
+		@include _oHeaderBreakpoint {
 			margin-right: $o-grid-gutter;
 		}
 	}
 
 	.o-header--tall & {
-		@include oHeaderBreakpoint {
+		@include _oHeaderBreakpoint {
 			> a {
 				height: 60px;
 			}
@@ -62,7 +62,7 @@
 	margin-right: $o-grid-gutter;
 
 	.o-header--tall & {
-		@include oHeaderBreakpoint {
+		@include _oHeaderBreakpoint {
 			max-height: 60px;
 		}
 	}
@@ -89,7 +89,7 @@
 		padding-top: 8px;
 	}
 
-	@include oHeaderBreakpoint {
+	@include _oHeaderBreakpoint {
 		width: 218px;
 
 		i {

--- a/src/scss/nav/theme-tools.scss
+++ b/src/scss/nav/theme-tools.scss
@@ -63,7 +63,6 @@
 			}
 		}
 	}
-	// scss-lint:enable NestingDepth SelectorDepth
 
 	// Styling for menu navs that appear when o-squishy-list comes into play
 	[data-o-hierarchical-nav-level] [data-o-hierarchical-nav-level] {
@@ -74,6 +73,7 @@
 			font-size: 14px;
 		}
 	}
+	// scss-lint:enable NestingDepth SelectorDepth
 }
 
 // Media queries to make the nav smaller as the screen gets smaller.
@@ -83,7 +83,7 @@
 	// Only show one item
 	width: 56px;
 
-	@include oHeaderBreakpoint {
+	@include _oHeaderBreakpoint {
 		// Show 2 items
 		width: 112px;
 	}


### PR DESCRIPTION
The `oHeaderBreakpoint` mixin should have been private. Since nobody uses this module yet, I guess it's still okay to release this as a patch?