### PR TITLE
Uses oGridTargetIE8 to get the expected larger header in ie8

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -26,7 +26,7 @@
             "template": "demos/src/header.mustache",
             "expanded": true,
             "description": "",
-            "documentClasses": "enhanced"
+            "documentClasses": "core"
         },
         {
             "name": "header-minimal",

--- a/origami.json
+++ b/origami.json
@@ -26,7 +26,7 @@
             "template": "demos/src/header.mustache",
             "expanded": true,
             "description": "",
-            "documentClasses": "core"
+            "documentClasses": "enhanced"
         },
         {
             "name": "header-minimal",

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -9,6 +9,10 @@
 		position: relative;
 	}
 
+	@include oGridTargetIE8 {
+		position: relative;
+	}
+
 	label > * {
 		pointer-events: none;
 	}
@@ -34,6 +38,10 @@
 	position: relative;
 
 	@include oGridRespondTo(M) {
+		display: block;
+	}
+
+	@include oGridTargetIE8 {
 		display: block;
 	}
 }

--- a/src/scss/_masthead.scss
+++ b/src/scss/_masthead.scss
@@ -32,6 +32,10 @@
 		display: none;
 	}
 
+	@include oGridTargetIE8 {
+		display: none;
+	}
+
 	> a {
 		@include oHeaderLogoLink;
 		@include oFtIconsGetSvg(brand-ft-masthead, oColorsGetColorFor(o-header, text), 138);

--- a/src/scss/_nav.scss
+++ b/src/scss/_nav.scss
@@ -17,6 +17,10 @@
 	@include oGridRespondTo(M) {
 		position: relative;
 	}
+
+	@include oGridTargetIE8 {
+		position: relative;
+	}
 }
 
 .o-header__nav,
@@ -46,6 +50,10 @@
 	display: none;
 
 	@include oGridRespondTo(L) {
+		display: inline-block;
+	}
+
+	@include oGridTargetIE8 {
 		display: inline-block;
 	}
 }

--- a/src/scss/_search.scss
+++ b/src/scss/_search.scss
@@ -1,5 +1,5 @@
 .o-header__search {
-	line-height: 24px;
+	line-height: 20px;
 	width: 45px;
 	float: right;
 

--- a/src/scss/_tools.scss
+++ b/src/scss/_tools.scss
@@ -15,10 +15,13 @@
 }
 
 .o-header__tools-item {
-	display: inline-block;
-	*zoom: 1;
-	*display: inline;
 	position: relative;
+	display: inline-block;
+
+	@include oGridTargetIE8 {
+		float: left;
+		padding: 0 6px;
+	}
 
 	&:before {
 		@include oColorsFor(o-header-tools-separator, background);

--- a/src/scss/_tools.scss
+++ b/src/scss/_tools.scss
@@ -16,6 +16,8 @@
 
 .o-header__tools-item {
 	display: inline-block;
+	*zoom: 1;
+	*display: inline;
 	position: relative;
 
 	&:before {


### PR DESCRIPTION
The tools nav is the only thing missing, and it's as if the inline-block doesn't work properly:

![header in ie8](https://cloud.githubusercontent.com/assets/913117/13702675/3cbd29bc-e788-11e5-912b-90ffa334c4b7.png)

It's the top right nav. I tried adding:

```
*zoom: 1;
*display: inline;
```

but no luck.

Any suggestions?