### PR TITLE
Remove: editionSwitcher flag logic

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@ const init = flags => {
 	preventScroll.init();
 	toggle.init(flags);
 	selected.init(flags);
-	editionSwitcher.init(document.querySelector('.edition-switcher'), flags);
+	editionSwitcher.init(document.querySelector('.edition-switcher'));
 };
 
 export default {

--- a/src/js/edition-switcher.js
+++ b/src/js/edition-switcher.js
@@ -23,9 +23,7 @@ class EditionSwitcher {
 }
 
 export default {
-	init: (editionSwitcherEl, flags) => {
-		if (flags.get('editionSwitcher')) {
-			new EditionSwitcher(editionSwitcherEl);
-		}
+	init: (editionSwitcherEl) => {
+		new EditionSwitcher(editionSwitcherEl);
 	}
 }

--- a/templates/header.html
+++ b/templates/header.html
@@ -12,7 +12,7 @@
 	<div class="o-grid-container">
 		<div class="o-grid-row">
 			<div class="o-header__masthead" data-o-grid-colspan="12">
-				{{#ifAll flags.editionSwitcher editions}}
+				{{#if editions}}
 					<div class="edition-switcher n-util-hide-no-js">
 						<button class="edition-switcher__button js-edition-switcher-button" data-trackable="edition-switcher-toggler">{{editions.current.name}} Edition</button>
 						<ul class="edition-switcher__editions" aria-hidden>
@@ -23,7 +23,7 @@
 							</li>
 						</ul>
 					</div>
-				{{/ifAll}}
+				{{/if}}
 				<div class="o-header__masthead__logo">
 					<a class="o-header__logo__link" data-trackable="logo-large" href="/" title="Go to Financial Times homepage">
 						<span class="n-util-visually-hidden">

--- a/templates/partials/all.html
+++ b/templates/partials/all.html
@@ -8,7 +8,7 @@
     {{/each}}
   </li>
 
-  {{#ifAll flags.editionSwitcher editions}}
+  {{#if editions}}
     <li class="navigation__menu__group__item navigation__menu__group__item--mobile">
       <div class="navigation__menu__group__container">
         <button class="navigation__menu__link--sub-level-header button-style-reset js-select selected" data-trackable="edition-switcher">
@@ -28,13 +28,13 @@
         </ol>
       </div>
     </li>
-  {{/ifAll}}
+  {{/if}}
 
   {{#each all}}
     {{#if children}}
       <li class="navigation__menu__group__item">
         <div class="navigation__menu__group__container">
-          <button class="navigation__menu__link--sub-level-header button-style-reset js-select {{#unless @root.flags.editionSwitcher}}{{#ifEquals @index 1}}selected{{/ifEquals}}{{/unless}}" data-navigation-href="{{href}}" data-trackable="{{name}}">
+          <button class="navigation__menu__link--sub-level-header button-style-reset js-select" data-navigation-href="{{href}}" data-trackable="{{name}}">
             <span class="navigation__menu__link navigation__menu__link--sub-level">{{name}}</span>
           </button>
           <ol class="navigation__menu__group__sub-items">


### PR DESCRIPTION
cc @ironsidevsquincy @wheresrhys 

Seems a good idea to remove this logic and delete the flag now (rather than having to keep extending its deadline) while we wait on final release.

Logic removed from `o-footer`: https://github.com/Financial-Times/o-footer/pull/48