### PR TITLE
Aligns columns properly with clear: both on first element of a row

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -35,13 +35,13 @@ class Utils {
 			// in the meganav so columns stay aligned. We want to
 			// apply it to desktop only columns, which isn't possible
 			// via CSS
-			const megaNavSections = this.headerEl.querySelectorAll('.o-header__meganav-section');
+			const megaNavSections = this.headerEl.querySelectorAll(`.${config.headerClassName}__meganav-section`);
 			let megaNavSectionPosition = 1;
 			for (let megaNavSection of megaNavSections) {
-				if (!megaNavSection.classList.contains('o-header__meganav-section--mobile')) {
+				if (!megaNavSection.classList.contains(`${config.headerClassName}__meganav-section--mobile`)) {
 					// If it's the first element in the row, add 'clear: both;' and move to next column
 					// If it's the last element in the row, reset for next row
-					// If otherwise, move to next columnd
+					// If otherwise, move to next column
 					switch (megaNavSectionPosition) {
 						case 1:
 							megaNavSection.style.clear = 'both';
@@ -49,7 +49,7 @@ class Utils {
 							break;
 						case 4:
 							megaNavSectionPosition = 1;
-							break
+							break;
 						default:
 							megaNavSectionPosition++;
 							break;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -25,11 +25,37 @@ class Utils {
 			selectableEl.addEventListener('click', this.selectableHandler);
 		}
 
-		const subNavToggle = this.headerEl.querySelector('[data-o-header-togglable-nav]');
-		this.subNavToggleHandler = this.subNavToggleHandler.bind(this);
-		if (subNavToggle) {
-			this.listeners.push([subNavToggle, this.subNavToggleHandler]);
-			subNavToggle.addEventListener('click', this.subNavToggleHandler);
+		const megaNavToggle = this.headerEl.querySelector('[data-o-header-togglable-nav]');
+		if (megaNavToggle) {
+			this.megaNavToggleHandler = this.megaNavToggleHandler.bind(this);
+			this.listeners.push([megaNavToggle, this.megaNavToggleHandler]);
+			megaNavToggle.addEventListener('click', this.megaNavToggleHandler);
+
+			// Applies 'clear: both;' to the first element in each row
+			// in the meganav so columns stay aligned. We want to
+			// apply it to desktop only columns, which isn't possible
+			// via CSS
+			const megaNavSections = this.headerEl.querySelectorAll('.o-header__meganav-section');
+			let megaNavSectionPosition = 1;
+			for (let megaNavSection of megaNavSections) {
+				if (!megaNavSection.classList.contains('o-header__meganav-section--mobile')) {
+					// If it's the first element in the row, add 'clear: both;' and move to next column
+					// If it's the last element in the row, reset for next row
+					// If otherwise, move to next columnd
+					switch (megaNavSectionPosition) {
+						case 1:
+							megaNavSection.style.clear = 'both';
+							megaNavSectionPosition++;
+							break;
+						case 4:
+							megaNavSectionPosition = 1;
+							break
+						default:
+							megaNavSectionPosition++;
+							break;
+					}
+				}
+			}
 		}
 
 		const toggleEls = this.headerEl.querySelectorAll('[data-o-header-togglable]');
@@ -47,7 +73,7 @@ class Utils {
 		ev.currentTarget.setAttribute('aria-selected', 'true');
 	}
 
-	subNavToggleHandler() {
+	megaNavToggleHandler() {
 		document.documentElement.classList.toggle(this.navOpenClass);
 		document.body.classList.toggle(this.navOpenClass);
 	}
@@ -68,7 +94,7 @@ class Utils {
 		delete this.listeners;
 		delete this.navOpenClass;
 		delete this.headerEl;
-		delete this.subNavToggleHandler;
+		delete this.megaNavToggleHandler;
 		delete this.selectableHandler;
 	}
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -19,8 +19,8 @@ describe('Utils API', () => {
 		expect(Utils.prototype.selectableHandler).to.be.a('function');
 	});
 
-	it('has a subNavToggleHandler instance method', () => {
-		expect(Utils.prototype.subNavToggleHandler).to.be.a('function');
+	it('has a megaNavToggleHandler instance method', () => {
+		expect(Utils.prototype.megaNavToggleHandler).to.be.a('function');
 	});
 
 	it('has a toggleHandler instance method', () => {
@@ -128,7 +128,7 @@ describe('Utils instance', () => {
 		});
 	});
 
-	describe('subNavToggle', () => {
+	describe('megaNavToggle', () => {
 		let navEl;
 
 		beforeEach(() => {
@@ -156,7 +156,7 @@ describe('Utils instance', () => {
 
 			const navEventAndHandler = addEventListenerSpy.args[0];
 			expect(navEventAndHandler[0]).to.be('click');
-			expect(navEventAndHandler[1]).to.be(utils.subNavToggleHandler);
+			expect(navEventAndHandler[1]).to.be(utils.megaNavToggleHandler);
 
 			// Removing
 			const realRemoveEventListener = Element.prototype.removeEventListener;
@@ -174,12 +174,12 @@ describe('Utils instance', () => {
 			Element.prototype.removeEventListener = realRemoveEventListener;
 		});
 
-		it('#subNavToggleHandler', () => {
+		it('#megaNavToggleHandler', () => {
 			const utils = new Utils(containerEl);
 			expect(document.documentElement.classList.contains('o-header--mega-nav-open')).to.be(false);
 			expect(document.body.classList.contains('o-header--mega-nav-open')).to.be(false);
 
-			utils.subNavToggleHandler();
+			utils.megaNavToggleHandler();
 			expect(document.documentElement.classList.contains('o-header--mega-nav-open')).to.be(true);
 			expect(document.body.classList.contains('o-header--mega-nav-open')).to.be(true);
 		});


### PR DESCRIPTION
It was implemented in JS as there are mobile specific columns that did not needed to be taken into account, and that wasn't possible just in CSS

Also renamed subNav to megaNav to keep it consistent with the rest of the codebase