### PR TITLE
Remove interaction with body to prevent scrolling when meganav is open

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -74,8 +74,7 @@ class Utils {
 	}
 
 	megaNavToggleHandler() {
-		document.documentElement.classList.toggle(this.navOpenClass);
-		document.body.classList.toggle(this.navOpenClass);
+		this.headerEl.classList.toggle(this.navOpenClass);
 	}
 
 	toggleHandler(ev) {

--- a/src/scss/_nav.scss
+++ b/src/scss/_nav.scss
@@ -1,12 +1,12 @@
 @if $o-header-is-silent == false {
 
-	// This is applied to the <body> via JS, this does not comply
-	// with the Origami spec, and issue #129 has been raised
+	// This is applied to the o-header element via JS
 	// It's used to avoid scrolling when the meganav
 	// is open in a mobile view
 	.o-header--mega-nav-open {
 		@include oGridRespondTo($until: M) {
-			overflow-y: hidden;
+			position: fixed;
+			width: 100%;
 			height: 100%;
 		}
 	}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -180,8 +180,7 @@ describe('Utils instance', () => {
 			expect(document.body.classList.contains('o-header--mega-nav-open')).to.be(false);
 
 			utils.megaNavToggleHandler();
-			expect(document.documentElement.classList.contains('o-header--mega-nav-open')).to.be(true);
-			expect(document.body.classList.contains('o-header--mega-nav-open')).to.be(true);
+			expect(utils.headerEl.classList.contains('o-header--mega-nav-open')).to.be(true);
 		});
 	});
 


### PR DESCRIPTION
Changed this to add `position:fixed` to the header element with `width` and `height` 100% to prevent scrolling. I've tested it across a variety of browsers including Android, iOS, and Windows and all seems OK.

@wheresrhys Alberto mentioned there might have been an issue with this in the past, let me know if you remember anything.

Closes #129 