### PR TITLE
Update masthead sizes to fix display on IE9-11

### DIFF
--- a/src/scss/_masthead.scss
+++ b/src/scss/_masthead.scss
@@ -15,10 +15,10 @@
 
 		> a {
 			@include oHeaderLogoLink;
-			@include oFtIconsGetSvg(brand-ft-masthead, oColorsGetColorFor(o-header, text), 336);
+			@include oFtIconsGetSvg(brand-ft-masthead, oColorsGetColorFor(o-header, text), 337);
 			display: block;
 			margin: 17px auto;
-			height: 27px;
+			height: 28px;
 		}
 	}
 
@@ -46,9 +46,9 @@
 			margin: 0 auto;
 
 			@include oGridRespondTo(S) {
-				@include oFtIconsGetSvg(brand-ft-masthead, oColorsGetColorFor(o-header, text), 265);
+				@include oFtIconsGetSvg(brand-ft-masthead, oColorsGetColorFor(o-header, text), 262);
 				display: block;
-				height: 21px;
+				height: 22px;
 			}
 		}
 	}


### PR DESCRIPTION
Changes the proportions of the masthead so the SVG renders correctly on IE9-11 and Edge. Increases masthead height by 1px, but hasn't introduced any obvious ill-effects.

Tested across a wide variety of browsers and seems to continue working as expected on non-IE/Edge browsers and is fixed on IE/Edge.

Before:
![screen shot 2016-04-25 at 11 42 18](https://cloud.githubusercontent.com/assets/1240073/14781548/1591e1c2-0adb-11e6-9ad9-8f098ff2f679.png)
After:
![screen shot 2016-04-25 at 11 41 27](https://cloud.githubusercontent.com/assets/1240073/14781549/159290a4-0adb-11e6-8712-3a6148269151.png)

Before:
![screen shot 2016-04-25 at 11 42 29](https://cloud.githubusercontent.com/assets/1240073/14781551/15957076-0adb-11e6-8617-f6711b036a15.png)
After:
![screen shot 2016-04-25 at 11 41 43](https://cloud.githubusercontent.com/assets/1240073/14781550/15931024-0adb-11e6-81c2-4419f659278c.png)

Fixes #154 