### PR TITLE
[Do not merge] Handle blur events so a sensible tab order is enforced

### DIFF
--- a/src/js/search.js
+++ b/src/js/search.js
@@ -11,13 +11,31 @@ class Search {
 		}
 
 		this.toggleEl = this.headerEl.querySelector('[data-o-header-togglable-search]');
+		this.menuToggleEl = this.headerEl.querySelector('[data-o-header-togglable-nav]');
+		this.searchButtonEl = this.headerEl.querySelector('.o-header__search-button');
 
 		if (this.toggleEl) {
 			this.inputEl = this.formEl.querySelector('input');
 			this.toggleHandler = this.searchToggleClickHandler.bind(this);
 			this.toggleEl.addEventListener('touchend', this.toggleHandler);
 			this.toggleEl.addEventListener('click', this.toggleHandler);
+
+			this.unfocusHander = this.searchUnFocusHandler.bind(this);
+			this.searchButtonEl.addEventListener('blur', this.unfocusHander);
+
+			this.removeTabindexOnBlur = this.toggleUnFocusHandler.bind(this);
 		}
+	}
+
+	searchUnFocusHandler() {
+		this.toggleEl.focus();
+		this.toggleEl.addEventListener('blur', this.removeTabindexOnBlur);
+		this.searchButtonEl.removeEventListener('blur', this.unfocusHander);
+	}
+
+	toggleUnFocusHandler() {
+		this.menuToggleEl.focus();
+		this.toggleEl.removeEventListener('blur', this.removeTabindexOnBlur);
 	}
 
 	searchToggleClickHandler() {
@@ -45,6 +63,8 @@ class Search {
 		}
 		delete this.headerEl;
 		delete this.formEl;
+		delete this.searchButtonEl;
+		delete this.menuToggleEl;
 	}
 }
 

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -110,7 +110,7 @@ describe('Search instance', () => {
 
 		expect(addEventListenerSpy.calledOn(search.toggleEl)).to.be(true);
 
-		expect(addEventListenerSpy.callCount).to.be(2);
+		expect(addEventListenerSpy.callCount).to.be(3);
 		const toucheEventAndHandler = addEventListenerSpy.args[0];
 		expect(toucheEventAndHandler[0]).to.be('touchend');
 		expect(toucheEventAndHandler[1]).to.be(search.toggleHandler);


### PR DESCRIPTION
So far, I'm finding that to get to the toggle button from the search button requires listening to the `blur` event on the search button, to redirect focus back to the toggle button. This works, but also requires that we listen to the `blur` event on the toggle button so we can direct it back to the nav.

The issue with this currently is that it only works when you're tabbing away from the search box the first time. When you return there's no way of retaining the tab-order without some possibly even nastier than what is already present hackery... 

Would be good to get some feedback on this approach and only having the correct tab order once... 