### PR TITLE
Adds proper core-enhanced support to search

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Some elements inside the header require specific data attributes so the JavaScri
 
 * data-o-header--no-js: Applied to the root element. This data attribute is removed when the JavaScript initialises
 * data-o-header-mega: Applied to the root `<div>` of the mega menu
+* data-o-header-search: Applied to the root `<div>` of the _enhanced_ search row. There are two search rows, one for enhanced, another for core
 
 ### Events
 

--- a/demos/src/header.mustache
+++ b/demos/src/header.mustache
@@ -45,6 +45,8 @@
 	{{/top}}
 
 	{{#search}}
+	<!-- To support both core and enhanced, duplicating the search row is necessary to avoid it flashing in enhanced -->
+	<!-- Pick only one of the two <div> if you don't need to support both core and enhanced -->
 	<div id="o-header-search" class="o-header__row o-header__search o--if-no-js" role="search">
 		<div class="o-header__container">
 			<form class="o-header__search-form" action="/search" role="search" aria-label="Site search">
@@ -56,11 +58,11 @@
 			</form>
 		</div>
 	</div>
-	<div id="o-header-search" class="o-header__row o-header__search" role="search" data-o-header-search>
+	<div id="o-header-search-js" class="o-header__row o-header__search" role="search" data-o-header-search>
 		<div class="o-header__container">
 			<form class="o-header__search-form" action="/search" role="search" aria-label="Site search">
-				<label class="o-header__visually-hidden" for="o-header-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
-				<input class="o-header__search-term" id="o-header-search-term" name="q" type="text" placeholder="Search the FT">
+				<label class="o-header__visually-hidden" for="o-header-search-term-js">Search the <abbr title="Financial Times">FT</abbr></label>
+				<input class="o-header__search-term" id="o-header-search-term-js" name="q" type="text" placeholder="Search the FT">
 				<button class="o-header__search-submit" type="submit">
 					Search
 				</button>

--- a/demos/src/header.mustache
+++ b/demos/src/header.mustache
@@ -53,7 +53,18 @@
 				<button class="o-header__search-submit" type="submit">
 					Search
 				</button>
-				<button class="o-header__search-close o--if-js" type="button" aria-controls="o-header-search">
+			</form>
+		</div>
+	</div>
+	<div id="o-header-search" class="o-header__row o-header__search" role="search" data-o-header-search>
+		<div class="o-header__container">
+			<form class="o-header__search-form" action="/search" role="search" aria-label="Site search">
+				<label class="o-header__visually-hidden" for="o-header-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
+				<input class="o-header__search-term" id="o-header-search-term" name="q" type="text" placeholder="Search the FT">
+				<button class="o-header__search-submit" type="submit">
+					Search
+				</button>
+				<button class="o-header__search-close" type="button" aria-controls="o-header-search">
 					<span class="o-header__visually-hidden">Close</span>
 				</button>
 			</form>

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -1,7 +1,7 @@
 import Toggle from 'o-toggle';
 
 function init (headerEl) {
-	const target = headerEl.querySelector('#o-header-search');
+	const target = headerEl.querySelector('[data-o-header-search');
 	const controls = target && headerEl.querySelectorAll(`[aria-controls="${target.id}"]`);
 
 	if (controls === null || controls.length === 0) {

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -1,8 +1,8 @@
 import Toggle from 'o-toggle';
 
 function init (headerEl) {
-	const target = headerEl.querySelector('[data-o-header-search');
-	const controls = target && headerEl.querySelectorAll(`[aria-controls="${target.id}"]`);
+	const target = headerEl.querySelector('[data-o-header-search]');
+	const controls = target && target.querySelectorAll(`[aria-controls="${target.id}"]`);
 
 	if (controls === null || controls.length === 0) {
 		return;

--- a/src/scss/rows/_search.scss
+++ b/src/scss/rows/_search.scss
@@ -10,6 +10,10 @@
 		}
 	}
 
+	[data-o-header-search] {
+		display: none;
+	}
+
 	.o-header__search-form {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
To support both core and enhanced, it's necessary to duplicate part of the markup to avoid the search row flashing in enhanced as it´s being hidden. Products can decide to support both, or just core or just enhanced