### PR TITLE
Hide the search close button for core folks

### DIFF
--- a/demos/src/header.mustache
+++ b/demos/src/header.mustache
@@ -66,7 +66,7 @@
 				<button class="o-header__search-submit" type="submit">
 					Search
 				</button>
-				<button class="o-header__search-close" type="button" aria-controls="o-header-search-js">
+				<button class="o-header__search-close o--if-js" type="button" aria-controls="o-header-search-js">
 					<span class="o-header__visually-hidden">Close</span>
 				</button>
 			</form>


### PR DESCRIPTION
Hides this close button for core-experience users:

![screenshot with close button that should be hidden](https://cloud.githubusercontent.com/assets/150157/16870694/d8730fa2-4a7a-11e6-82b3-aa4e3b95ad8f.png)

(It‘s only used in order to hide the whole search bar, for enhanced users.)