### PR TITLE
Mixinify drawer

### DIFF
--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -1,4 +1,4 @@
-@if $o-header-is-silent == false {
+@mixin oHeaderDrawer() {
 
 	// added to the document element, see n-ui/layout
 	.o-header__drawer {
@@ -342,4 +342,8 @@
 		margin-top: 0.25em;
 		font-size: 14px;
 	}
+}
+
+@if $o-header-is-silent == false {
+	@include oHeaderDrawer();
 }


### PR DESCRIPTION
The drawer is being used by (the soon to be renamed) o-header-subbrand.
So that o-header-subbrand doesn't need to include the whole of o-header, this commit
makes the drawer available as a mixin and then calls it from itself in the same
way that o-header-subbrand will