### PR TITLE
Add visually hidden styles to mixin

### DIFF
--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -23,14 +23,7 @@
 	}
 
 	.o-header__visually-hidden {
-		position: absolute;
-		clip: rect(0 0 0 0);
-		margin: -1px;
-		border: 0;
-		overflow: hidden;
-		padding: 0;
-		width: 1px;
-		height: 1px;
+		@include oHeaderVisuallyHidden;
 	}
 
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -90,3 +90,14 @@
 	background-image: url($base-url + $logo-name + "?source=o-header&tint=%23#{$color},%23#{$color}&format=svg");
 	background-image: url($base-url + $logo-name + "?source=o-header&tint=%23#{$color},%23#{$color}&format=png&width=#{$fallback-width}") \9;
 }
+
+@mixin oHeaderVisuallyHidden() {
+	position: absolute;
+	clip: rect(0 0 0 0);
+	margin: -1px;
+	border: 0;
+	overflow: hidden;
+	padding: 0;
+	width: 1px;
+	height: 1px;
+}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -91,6 +91,8 @@
 	background-image: url($base-url + $logo-name + "?source=o-header&tint=%23#{$color},%23#{$color}&format=png&width=#{$fallback-width}") \9;
 }
 
+/// Applies styles to hide an element accessibly,
+/// allowing the content to be read by screenreaders.
 @mixin oHeaderVisuallyHidden() {
 	position: absolute;
 	clip: rect(0 0 0 0);


### PR DESCRIPTION
Moves the visually hidden styles into a mixin so they can be used by other components with `o-header` in silent mode. This is mostly for  `o-header-services` which is recreating the drawer which requires the class for the close button.