### PR TITLE
Add vertical align to search close to fix alignment in IE9

### DIFF
--- a/src/scss/rows/_search.scss
+++ b/src/scss/rows/_search.scss
@@ -57,6 +57,7 @@
 
 	.o-header__search-close {
 		@include oIconsGetIcon('cross', white, 20);
+		vertical-align: middle;
 		border: 0;
 		margin-left: $_o-header-padding-x * 2;
 


### PR DESCRIPTION
Fixes #208 