### PR TITLE
New icons

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "o-buttons": "^4.0.1",
     "o-colors": "^3.3.2",
     "o-grid": "^4.2.0",
-    "o-icons": "^4.2.0",
+    "o-icons": "^4.4.2",
     "o-typography": "^4.1.0",
     "o-visual-effects": "^0.1.0",
     "o-toggle": "^1.0.0",

--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -174,7 +174,6 @@
 			@include oIconsGetIcon('search', oColorsGetPaletteColor('white'), $_o-header-icon-size, $iconset-version: 1);
 			content: '';
 			margin-top: -($_o-header-drawer-padding-y / 2);
-
 		}
 	}
 

--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -75,7 +75,7 @@
 	//
 	.o-header__drawer-tools {
 		overflow: hidden;
-		padding: ($_o-header-drawer-padding-y * 1.5) $_o-header-drawer-padding-x $_o-header-drawer-padding-y;
+		padding: ($_o-header-drawer-padding-y * 1.5) 0 $_o-header-drawer-padding-y $_o-header-drawer-padding-x;
 	}
 
 	.o-header__drawer-tools-logo {
@@ -88,12 +88,12 @@
 
 	.o-header__drawer-tools-close {
 		// dividing by 1px removes the unit
-		@include oIconsGetIcon('cross', oColorsGetPaletteColor('grey-tint4'), 18);
+		@include oIconsGetIcon('cross', oColorsGetPaletteColor('grey-tint4'), $_o-header-icon-size-large, $iconset-version: 1);
 		float: right;
 		border: 0;
 		opacity: 0.75;
 		cursor: pointer;
-
+		margin-top: -10px;
 		&:hover,
 		&:focus {
 			opacity: 1;
@@ -152,7 +152,7 @@
 		box-sizing: border-box;
 		// ಥ_ಥ
 		height: 32px;
-		padding: ($_o-header-drawer-padding-y / 2) ($_o-header-drawer-padding-x / 2);
+		padding: 8px ($_o-header-drawer-padding-x / 2);
 		border: 1px solid;
 		// prevent zoom on focus
 		font-size: 100%;
@@ -171,8 +171,10 @@
 		@include oColorsFor(o-header-drawer-search-submit);
 
 		&:after {
-			@include oIconsGetIcon('search', oColorsGetPaletteColor('white'), 16);
+			@include oIconsGetIcon('search', oColorsGetPaletteColor('white'), $_o-header-icon-size, $iconset-version: 1);
 			content: '';
+			margin-top: -($_o-header-drawer-padding-y / 2);
+
 		}
 	}
 
@@ -249,12 +251,12 @@
 		text-align: left;
 		border: 0;
 		cursor: pointer;
-		// visually hide text... so ghetto
+		// visually hide text...
 		font-size: 0;
 
 		&:before {
 			content: ' ';
-			margin-left: 14px;
+			margin-left: 9px; // magic number to vertically align icon in box
 		}
 
 		&[aria-expanded="true"] {
@@ -278,7 +280,7 @@
 		background: rgba(oColorsGetColorFor(o-header-drawer-toggle-selected, background), 0.25);
 
 		&:before {
-			@include oIconsGetIcon('arrow-down', oColorsGetColorFor(o-header-drawer-toggle-selected, text), 14);
+			@include oIconsGetIcon('arrow-down', oColorsGetColorFor(o-header-drawer-toggle-selected, text), $_o-header-icon-size, $iconset-version: 1);
 		}
 	}
 
@@ -286,7 +288,7 @@
 		background: rgba(oColorsGetColorFor(o-header-drawer-toggle-unselected, background), 0.85);
 
 		&:before {
-			@include oIconsGetIcon('arrow-down', oColorsGetColorFor(o-header-drawer-toggle-unselected, text), 14);
+			@include oIconsGetIcon('arrow-down', oColorsGetColorFor(o-header-drawer-toggle-unselected, text), $_o-header-icon-size, $iconset-version: 1);
 		}
 	}
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -14,3 +14,8 @@ $_o-header-drawer-padding-x: 16px;
 $_o-header-drawer-padding-y: 12px;
 $_o-header-sticky-z-index: 99;
 $_o-header-sticky-height: 55px;
+
+/* at some point these should be normalised in o-icons */
+$_o-header-icon-size-large: 40;
+$_o-header-icon-size: 25;
+$_o-header-icon-size-small: 15;

--- a/src/scss/mega/articles.scss
+++ b/src/scss/mega/articles.scss
@@ -4,7 +4,8 @@
 
 		.o-header__mega-item {
 			&:before {
-				@include oIconsGetIcon('arrow-right', oColorsGetPaletteColor('claret-1'), 10);
+				@include oIconsGetIcon('arrow-right', oColorsGetPaletteColor('claret-1'), $_o-header-icon-size-small, $iconset-version: 1);
+				vertical-align: text-top;
 				content: '';
 			}
 		}

--- a/src/scss/rows/_search.scss
+++ b/src/scss/rows/_search.scss
@@ -56,10 +56,9 @@
 	}
 
 	.o-header__search-close {
-		@include oIconsGetIcon('cross', white, 20);
-		vertical-align: middle;
+		@include oIconsGetIcon('cross', white, $_o-header-icon-size-large, $iconset-version: 1);
 		border: 0;
-		margin-left: $_o-header-padding-x * 2;
+		margin-left: $_o-header-padding-x;
 
 		@include oGridRespondTo($until: 'M') {
 			display: none;

--- a/src/scss/rows/_search.scss
+++ b/src/scss/rows/_search.scss
@@ -59,6 +59,7 @@
 		@include oIconsGetIcon('cross', white, $_o-header-icon-size-large, $iconset-version: 1);
 		border: 0;
 		margin-left: $_o-header-padding-x;
+		vertical-align: middle;
 
 		@include oGridRespondTo($until: 'M') {
 			display: none;

--- a/src/scss/rows/_subnav.scss
+++ b/src/scss/rows/_subnav.scss
@@ -62,7 +62,7 @@
 
 		.o-header__subnav-list--breadcrumb & {
 			&:before {
-				@include oIconsGetIcon('arrow-right', oColorsGetColorFor(o-header-link-highlight, text), 13);
+				@include oIconsGetIcon('arrow-right', oColorsGetColorFor(o-header-link-highlight, text), $_o-header-icon-size-small, $iconset-version: 1);
 				content: '';
 				position: relative;
 				top: 0.125em;
@@ -94,15 +94,15 @@
 	}
 
 	.o-header__subnav-button {
-		@include oIconsGetIcon('arrow-left', oColorsGetColorFor(o-header-subnav-button, text), $apply-width-height: false);
+		@include oIconsGetIcon('arrow-left', oColorsGetColorFor(o-header-subnav-button, text), $_o-header-icon-size-small, $apply-width-height: false, $iconset-version: 1);
 		@include oColorsFor(o-header-subnav-button, background);
 		position: absolute;
 		top: 0;
-		width: 24px;
+		width: #{$_o-header-icon-size-small}px;
 		height: 100%;
 		padding: 0;
 		border: 0;
-		background-size: 12px;
+		background-size: 30px;
 		transition: 0.25s opacity 0.5s;
 
 		&:hover {

--- a/src/scss/rows/_subnav.scss
+++ b/src/scss/rows/_subnav.scss
@@ -94,15 +94,14 @@
 	}
 
 	.o-header__subnav-button {
-		@include oIconsGetIcon('arrow-left', oColorsGetColorFor(o-header-subnav-button, text), $_o-header-icon-size-small, $apply-width-height: false, $iconset-version: 1);
+		@include oIconsGetIcon('arrow-left', oColorsGetColorFor(o-header-subnav-button, text), $_o-header-icon-size, $apply-width-height: false, $iconset-version: 1);
 		@include oColorsFor(o-header-subnav-button, background);
 		position: absolute;
 		top: 0;
-		width: #{$_o-header-icon-size-small}px;
+		width: #{$_o-header-icon-size}px;
 		height: 100%;
 		padding: 0;
 		border: 0;
-		background-size: 30px;
 		transition: 0.25s opacity 0.5s;
 
 		&:hover {

--- a/src/scss/rows/_top.scss
+++ b/src/scss/rows/_top.scss
@@ -55,8 +55,9 @@
 		&:before {
 			@include oIconsBaseStyles();
 			content: ' ';
-			width: 20px;
-			height: 20px;
+			margin-top: -7px;
+			width: #{$_o-header-icon-size-large}px;
+			height: #{$_o-header-icon-size-large}px;
 		}
 
 		@include oGridRespondTo('L') {
@@ -73,13 +74,13 @@
 		&:before {
 			// container size (24) is only included for the fallback image.
 			// IE8 has a static stylesheet generated for the L breakpoint.
-			@include oIconsGetIcon('hamburger', oColorsGetColorFor('o-header-icon'), 24, $apply-base-styles: false, $apply-width-height: false);
+			@include oIconsGetIcon('hamburger', oColorsGetColorFor('o-header-icon'), $_o-header-icon-size-large, $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
 		}
 	}
 
 	.o-header__top-link--search {
 		&:before {
-			@include oIconsGetIcon('search', oColorsGetColorFor('o-header-icon'), 24, $apply-base-styles: false, $apply-width-height: false);
+			@include oIconsGetIcon('search', oColorsGetColorFor('o-header-icon'), $_o-header-icon-size-large, $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
 		}
 
 		// when used in tandem with the menu toggle, hide this on smaller screen sizes
@@ -108,7 +109,7 @@
 
 	.o-header__top-link-label {
 		display: block;
-		margin-top: 2px;
+		margin-top: -7px;
 	}
 
 	.o-header__top-logo {


### PR DESCRIPTION
The icon set has been redesigned. You can see it here: https://github.com/Financial-Times/fticons.

This PR updates o-header to use the new set, which is available through o-icons v4.4.2 as long as you're using the oIconsGetSVG mixin.

Because these icons have changed a bit, i've had to jig around some padding values so everything still lines up as intended. This has been checked over with Oli on the design team.

SCREENSHOT DIFFS:

|before | after 
---------|-------
![drawer-old](https://cloud.githubusercontent.com/assets/68009/18358445/fded5e7a-75ec-11e6-85c0-cceccc4951ca.png)|![drawer-new](https://cloud.githubusercontent.com/assets/68009/18358619/da972c3e-75ed-11e6-93ce-c2543e1349a4.png)
![subnav-old](https://cloud.githubusercontent.com/assets/68009/18358745/8717b6fe-75ee-11e6-8b03-149a58aba582.png)|![sub-nav-new](https://cloud.githubusercontent.com/assets/68009/18358749/8b67e1d4-75ee-11e6-9d7c-5deb71ca5f31.png)
![menu-search-old](https://cloud.githubusercontent.com/assets/68009/18358830/033820c0-75ef-11e6-83d6-b745b8255da2.png)|![menu-search-new](https://cloud.githubusercontent.com/assets/68009/18358834/06adb904-75ef-11e6-8cf9-0a0c54ab590f.png)








