### PR TITLE
Widen o-icons semver range

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "o-buttons": "^4.0.1",
     "o-colors": "^3.3.2",
     "o-grid": "^4.2.0",
-    "o-icons": "^4.4.2",
+    "o-icons": ">=4.4.2 <6",
     "o-typography": "^4.1.0",
     "o-visual-effects": "^0.1.0",
     "o-toggle": "^1.0.0",


### PR DESCRIPTION
So that projects can choose to migrate o-icons to v5 or leave it,
this commit widens the accepted semver range for o-icons to anything
above 4.4.2 but less than the next major (which would be 6)