### PR TITLE
Remove Next dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Some elements inside the header require specific data attributes so the JavaScri
 * data-o-header-mega: Applied to the root `<div>` of the mega menu
 * data-o-header-search: Applied to the root `<div>` of the _enhanced_ search row. There are two search rows, one for enhanced, another for core
 * data-o-header-drawer: Applied to the root `<div>` of the drawer
-* data-o-header-drawer-user-email: Applied to the `<span>` inside of the drawer that will host the user's email
 * data-o-header-subnav: Applied to the root `div` of the subnav menu
 * data-o-header-subnav-wrapper: Applied to the inner wrapper `div` of the subnav menu so the JS can handle the scrolling
 

--- a/demos/src/header.mustache
+++ b/demos/src/header.mustache
@@ -199,7 +199,6 @@
 						<li class="o-header__drawer-menu-item">
 							<a class="o-header__drawer-menu-link" href="https://myaccount.ft.com/details/core/view">
 								{{user.name}}
-								<span class="o-header__drawer-menu-link-detail" data-o-header-drawer-user-email></span>
 							</a>
 						</li>
 						<li class="o-header__drawer-menu-item">

--- a/demos/src/simple-header.mustache
+++ b/demos/src/simple-header.mustache
@@ -130,7 +130,6 @@
 						<li class="o-header__drawer-menu-item">
 							<a class="o-header__drawer-menu-link" href="https://myaccount.ft.com/details/core/view">
 								{{user.name}}
-								<span class="o-header__drawer-menu-link-detail" data-o-header-drawer-user-email></span>
 							</a>
 						</li>
 						<li class="o-header__drawer-menu-item">

--- a/demos/src/sticky-header.mustache
+++ b/demos/src/sticky-header.mustache
@@ -161,7 +161,6 @@
 						<li class="o-header__drawer-menu-item">
 							<a class="o-header__drawer-menu-link" href="https://myaccount.ft.com/details/core/view">
 								{{user.name}}
-								<span class="o-header__drawer-menu-link-detail" data-o-header-drawer-user-email></span>
 							</a>
 						</li>
 						<li class="o-header__drawer-menu-item">

--- a/demos/src/subbrand.mustache
+++ b/demos/src/subbrand.mustache
@@ -126,7 +126,6 @@
 						<li class="o-header__drawer-menu-item">
 							<a class="o-header__drawer-menu-link" href="https://myaccount.ft.com/details/core/view">
 								{{user.name}}
-								<span class="o-header__drawer-menu-link-detail" data-o-header-drawer-user-email></span>
 							</a>
 						</li>
 						<li class="o-header__drawer-menu-item">

--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -96,22 +96,6 @@ function addSubmenuToggles (drawerEl) {
 	});
 }
 
-function appendUserDetail (target) {
-	return fetch('https://session-next.ft.com/', {
-		credentials: 'include'
-	})
-	.then((response) => {
-		if (response.ok) {
-			return response.json();
-		} else {
-			return response.text().then((err) => { throw new Error(err); });
-		}
-	})
-	.then((data) => {
-		target.innerText = data.emailAddress;
-	});
-}
-
 function init () {
 	const drawerEl = document.body.querySelector('[data-o-header-drawer]');
 	if (!drawerEl) {
@@ -119,13 +103,6 @@ function init () {
 	}
 	addSubmenuToggles(drawerEl);
 	addDrawerToggles(drawerEl);
-
-	const emailEl = drawerEl.querySelector('[data-o-header-drawer-user-email]');
-
-	// if the browser doesn't support CORS then bail
-	if (emailEl && ('withCredentials' in new XMLHttpRequest())) {
-		appendUserDetail(emailEl);
-	}
 
 	drawerEl.removeAttribute('data-o-header-drawer--no-js');
 	drawerEl.setAttribute('data-o-header-drawer--js', 'true');


### PR DESCRIPTION
- Shared Origami components must not have dependencies on Next frontend applications.
- This is built on DAM functionality, being turned off in late November.
- UX aren't fussed about the feature.