### PR TITLE
Fix left alignment for nav items

### DIFF
--- a/src/scss/features/_nav.scss
+++ b/src/scss/features/_nav.scss
@@ -45,6 +45,10 @@
 
 		.o-header__nav--mobile & {
 			padding-left: $_o-header-padding-x * 2;
+
+			&:first-child {
+				padding-left: 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
For FT.com at narrow screen widths the nav-items are centrally
aligned. However on Alphaville, these items remain left aligned.
This change of padding means the alignment is incorrect at mobile
widths.

This commit fixes that, meaning at mobile widths the nav items continue
to butt up to the left hand side as expected.