### PR TITLE
Remove icon labels + align to middle

### DIFF
--- a/src/scss/features/_simple.scss
+++ b/src/scss/features/_simple.scss
@@ -6,7 +6,7 @@
 		}
 
 		.o-header__top-link {
-			margin-top:4px;
+			margin-top: 4px;
 			margin-bottom: 4px;
 		}
 

--- a/src/scss/features/_simple.scss
+++ b/src/scss/features/_simple.scss
@@ -5,6 +5,11 @@
 			height: $_o-header-sticky-height;
 		}
 
+		.o-header__top-link {
+			margin-top:4px;
+			margin-bottom: 4px;
+		}
+
 		.o-header__top-logo {
 			margin-top: 0;
 			margin-bottom: 0;

--- a/src/scss/features/_top.scss
+++ b/src/scss/features/_top.scss
@@ -50,15 +50,24 @@
 		text-transform: uppercase;
 		font-size: 10px;
 		text-align: center;
+		height: 40px;
+		margin-top: 4px;
+		margin-bottom: 4px;
 
 		@include oGridRespondTo('L') {
 			margin-left: 20px;
+			margin-top: 30px;
+			margin-bottom: 30px;
+		}
+
+		@include oGridRespondTo('M') {
+			margin-top: 24px;
+			margin-bottom: 24px;
 		}
 
 		&:before {
 			@include oIconsBaseStyles();
 			content: ' ';
-			margin-top: -7px;
 			width: #{$_o-header-icon-size-large}px;
 			height: #{$_o-header-icon-size-large}px;
 		}
@@ -109,8 +118,11 @@
 	}
 
 	.o-header__top-link-label {
-		display: block;
-		margin-top: -7px;
+		/* Deprecate this label in next breaking release (v7), but for v6.12.0
+			display-none it so that layout won't break and people don't have
+			to update their markup to get the change
+		*/
+		display: none;
 	}
 
 	.o-header__top-logo {


### PR DESCRIPTION
This commit removes the 'menu' and 'search' label and aligns the icons to the middle of the header.

Before
<img width="1238" alt="screen shot 2016-11-21 at 10 44 40" src="https://cloud.githubusercontent.com/assets/68009/20479831/a496468c-afd7-11e6-9574-c3585964277a.png">

After
<img width="1235" alt="screen shot 2016-11-21 at 10 18 20" src="https://cloud.githubusercontent.com/assets/68009/20479738/3a086a7a-afd7-11e6-8d20-4d781eab81db.png">


Before
<img width="325" alt="screen shot 2016-11-21 at 10 44 14" src="https://cloud.githubusercontent.com/assets/68009/20479949/3a6e1d9c-afd8-11e6-94a6-0c0b6ed85006.png">

After
<img width="403" alt="screen shot 2016-11-21 at 10 48 31" src="https://cloud.githubusercontent.com/assets/68009/20479944/375b723a-afd8-11e6-880d-38c4e432cd37.png">