### PR TITLE
Switch to obt v5 whilst waiting on a sass-lint fix

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,9 @@
 machine:
   node:
     version: 6
+# use OBT v5 until https://github.com/sasstools/sass-lint/pull/957 is merged
   post:
-    - npm install -g origami-build-tools
+    - npm install -g origami-build-tools@^5
 dependencies:
   override:
     - obt install


### PR DESCRIPTION
Whilst we wait for https://github.com/sasstools/sass-lint/pull/957 to be merged and released, we should revert to using obt v5 which uses scss-lint.