### PR TITLE
Style: Drawer selected menu link focus state

### DIFF
--- a/src/scss/features/_drawer.scss
+++ b/src/scss/features/_drawer.scss
@@ -321,8 +321,10 @@
 	.o-header__drawer-menu-link--selected {
 		@include oColorsFor(o-header-drawer-menu-link-selected);
 
-		&:hover {
+		&:hover,
+		&:focus {
 			@include oColorsFor(o-header-drawer-menu-link-hover-selected, text);
+			outline-color: oColorsGetColorFor('o-header-drawer-menu', 'text');
 		}
 
 		[aria-expanded="true"] + & {


### PR DESCRIPTION
cc @i-like-robots @onishiweb 

Address drawer menu scenario in https://github.com/Financial-Times/next-a11y/issues/18

### Before
![before](https://cloud.githubusercontent.com/assets/10484515/21350799/47a9b9b8-c6b1-11e6-955b-53e5d90aaf9b.png)

### After
![after](https://cloud.githubusercontent.com/assets/10484515/21350803/4b1bc2bc-c6b1-11e6-85b0-ea7b44df8129.png)