### PR TITLE
Remove usage of h3 in demos

### DIFF
--- a/demos/src/mega-menu.mustache
+++ b/demos/src/mega-menu.mustache
@@ -21,9 +21,9 @@
 						<div class="o-header__container">
 							<div class="o-header__mega-wrapper">
 								<div class="o-header__mega-column o-header__mega-column--subsections">
-									<h3 class="o-header__mega-heading">
+									<div class="o-header__mega-heading">
 										Sub-sections
-									</h3>
+									</div>
 									<div class="o-header__mega-content">
 										<ul class="o-header__mega-list">
 											{{#subsections}}
@@ -37,9 +37,9 @@
 									</div>
 								</div>
 								<div class="o-header__mega-column o-header__mega-column--articles">
-									<h3 class="o-header__mega-heading">
+									<div class="o-header__mega-heading">
 										Top Stories
-									</h3>
+									</div>
 									<div class="o-header__mega-content">
 										<ul class="o-header__mega-list">
 											{{#articles}}

--- a/demos/src/transparent-header.mustache
+++ b/demos/src/transparent-header.mustache
@@ -60,9 +60,9 @@
 						<div class="o-header__container">
 							<div class="o-header__mega-wrapper">
 								<div class="o-header__mega-column o-header__mega-column--subsections">
-									<h3 class="o-header__mega-heading">
+									<div class="o-header__mega-heading">
 										Sub-sections
-									</h3>
+									</div>
 									<div class="o-header__mega-content">
 										<ul class="o-header__mega-list">
 											{{#subsections}}
@@ -76,9 +76,9 @@
 									</div>
 								</div>
 								<div class="o-header__mega-column o-header__mega-column--articles">
-									<h3 class="o-header__mega-heading">
+									<div class="o-header__mega-heading">
 										Top Stories
-									</h3>
+									</div>
 									<div class="o-header__mega-content">
 										<ul class="o-header__mega-list">
 											{{#articles}}


### PR DESCRIPTION
Turned `H3`s into `div`s to discourage heading usage out of context

Using `H3`s this way in this component caused FT.com pages to have `H3`s before the `H1`, breaking a few WCAG2.0 rules
