### PR TITLE
A11y: Focus on the first focusable element inside the drawer 

### DIFF
--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -93,7 +93,13 @@ function addDrawerToggles (drawerEl) {
 				// Don't focus on the drawer itself or iOS VoiceOver will miss it
 				// Focus on the first focusable element
 				const firstFocusable = drawerEl.querySelector('a, button, input, select');
-				firstFocusable && firstFocusable.focus();
+
+				if (firstFocusable) {
+					firstFocusable.focus();
+				}
+				else {
+					drawerEl.focus();
+				}
 			});
 		}
 

--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -89,7 +89,12 @@ function addDrawerToggles (drawerEl) {
 
 			// aria-controls is only supported by JAWS.
 			// In a setTimeout callback to avoid flickering transitions in Chrome (v54)
-			setTimeout(() => drawerEl.focus());
+			setTimeout(() => {
+				// Don't focus on the drawer itself or iOS VoiceOver will miss it
+				// Focus on the first focusable element
+				const firstFocusable = drawerEl.querySelector('a, button, input, select');
+				firstFocusable && firstFocusable.focus();
+			});
 		}
 
 		drawerEl.classList.toggle('o-header__drawer--closing', state === 'close');


### PR DESCRIPTION
Clicking the hamburger sends focus to the first focusable element inside the drawer rather than the drawer itself.

VO on iOS fails to catch focus when focusing on the drawer itself (so users are left "behind" the menu), but works ok when focused on something insde it.

Hacky example: https://jsbin.com/wexanuzecu/1/edit?html,css,js,output

Last bug before we get AA accredited 🍾 