### PR TITLE
Use consistent default export style

### DIFF
--- a/src/js/subnav.js
+++ b/src/js/subnav.js
@@ -57,4 +57,4 @@ function init(headerEl) {
 	scrollable();
 }
 
-module.exports = { init };
+export default { init };


### PR DESCRIPTION
This one file uses a different export style from everything else, which causes headaches when using this module with Rollup.