### PR TITLE
Specify font-family for .o-header__drawer elements

### DIFF
--- a/src/scss/features/_drawer.scss
+++ b/src/scss/features/_drawer.scss
@@ -2,6 +2,7 @@
 	// added to the document element, see n-ui/layout
 	.o-header__drawer {
 		@include oColorsFor(o-header-drawer, background);
+		font-family: $o-typography-sans;
 
 		&[data-o-header-drawer--js] {
 			position: fixed;


### PR DESCRIPTION
add `font-family: $o-typography-sans` to `.o-header__drawer`