### PR TITLE
Remove .o-header__nav--mobile background

### DIFF
--- a/src/scss/_colors.scss
+++ b/src/scss/_colors.scss
@@ -13,7 +13,9 @@
 @include oColorsSetUseCase('o-header-transparent-link-hover', 'text', 'white');
 @include oColorsSetUseCase('o-header-transparent-link-highlight', 'text', 'white');
 
+// @deprecated o-header-nav background no longer used
 @include oColorsSetUseCase('o-header-nav', 'background', 'white-60');
+// @deprecated o-header-nav background no longer used
 
 @include oColorsSetUseCase('o-header-search', 'border', 'teal-40');
 @include oColorsSetUseCase('o-header-search', 'background', 'black-20');

--- a/src/scss/features/_nav.scss
+++ b/src/scss/features/_nav.scss
@@ -6,7 +6,6 @@
 
 	.o-header__nav--mobile {
 		white-space: nowrap;
-		background-color: oColorsGetColorFor('o-header-nav', 'background');
 
 		@include oGridRespondTo('L') {
 			display: none;


### PR DESCRIPTION
https://github.com/Financial-Times/o-header/issues/264

before
![screen shot 2017-09-27 at 11 23 36](https://user-images.githubusercontent.com/10405691/30908709-57a19366-a376-11e7-9a0e-010a76ac7dbe.png)

after
![screen shot 2017-09-27 at 11 22 59](https://user-images.githubusercontent.com/10405691/30908717-5d57e2f6-a376-11e7-80ed-fb232f5f032b.png)