### PR TITLE
Allow focus state to overflow in subnav.

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -26,6 +26,7 @@ $_o-header-sticky-height: 55px;
 $_o-header-subhav-height-medium: 32px;
 $_o-header-subhav-height-base: 42px;
 $_o-header-item-separator-percentage-height: 0.7;
+$_o-header-sub-header-focus-margin: 5px;
 
 /* at some point these should be normalised in o-icons */
 $_o-header-icon-size-large: 40;

--- a/src/scss/features/_subnav.scss
+++ b/src/scss/features/_subnav.scss
@@ -16,6 +16,7 @@
 			// height *needs* setting so we can hide scrollbars.
 			// This is the content height of .o-header__subnav-content
 			height: $_o-header-subhav-height-base;
+			margin-left: -$_o-header-sub-header-focus-margin;
 
 			@include oGridRespondTo('M') {
 				height: $_o-header-subhav-height-medium;
@@ -40,6 +41,7 @@
 
 	.o-header__subnav-content {
 		white-space: nowrap;
+		margin-left: $_o-header-sub-header-focus-margin;
 	}
 
 	.o-header__subnav-list {


### PR DESCRIPTION
![kapture 2017-10-18 at 10 47 11](https://user-images.githubusercontent.com/10405691/31712163-2acc0eca-b3f2-11e7-85b6-6330884faf2f.gif)

https://github.com/Financial-Times/n-ui/blob/0d5b30f80f1be2c5067d7532a8d25374b19ab58c/components/n-ui/header/main.scss#L15

`n-ui` uses a similar negative margin workaround to reveal the subnav items focus state despite the hidden overflow of the subnav. Here we take the same approach but apply the counter margin to `.o-header__subnav-content` rather than `.o-header__subnav-list--breadcrumb .o-header__subnav-item:first-child .o-header__subnav-link`, incase the breadcrumb isn't present.

We use 5px rather than 2px to meet Chrome's default on OSX. This is an arbitrary value but should meet other browsers needs also. Perhaps we should use [o-normalise](https://github.com/Financial-Times/o-normalise/blob/master/src/scss/_mixins.scss#L56) like @JakeChampion suggested, but I'm not sure how that would work without including it as a dependancy to each component, duplicating the normalise styles within a project.

issue: https://github.com/Financial-Times/o-header/issues/269