### PR TITLE
Set background size explicitly to improve header masthead rendering …

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -102,11 +102,8 @@
 @mixin oHeaderLogoSize($breakpoint) {
 	$image-aspect-ratio: 25 / 2;
 	$logo-heights: ('XS': 16, 'S': 20, 'M': 24, 'L': 40, 'XL': 40);
-	$width: map-get($logo-heights, $breakpoint) * $image-aspect-ratio + 0px;
-	$height: map-get($logo-heights, $breakpoint) + 0px;
-	width: $width;
-	height: $height;
-	background-size: $width $height; // Edge SVG background clipped when scaled https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4705340/
+	width: map-get($logo-heights, $breakpoint) * $image-aspect-ratio + 0px;
+	height: map-get($logo-heights, $breakpoint) + 0px;
 }
 
 /// Construct a logo image URL

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -102,9 +102,11 @@
 @mixin oHeaderLogoSize($breakpoint) {
 	$image-aspect-ratio: 25 / 2;
 	$logo-heights: ('XS': 16, 'S': 20, 'M': 24, 'L': 40, 'XL': 40);
-
-	width: map-get($logo-heights, $breakpoint) * $image-aspect-ratio + 0px;
-	height: map-get($logo-heights, $breakpoint) + 0px;
+	$width: map-get($logo-heights, $breakpoint) * $image-aspect-ratio + 0px;
+	$height: map-get($logo-heights, $breakpoint) + 0px;
+	width: $width;
+	height: $height;
+	background-size: $width $height; // Edge SVG background clipped when scaled https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4705340/
 }
 
 /// Construct a logo image URL

--- a/src/scss/features/_top.scss
+++ b/src/scss/features/_top.scss
@@ -135,6 +135,7 @@
 		background-size: contain;
 		background-position: 50%;
 		background-repeat: no-repeat;
+		background-size: 100% 100%; // Edge SVG background clipped when scaled https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4705340/
 
 		@include oGridRespondTo('S') {
 			@include oHeaderLogoSize('S');

--- a/src/scss/features/_top.scss
+++ b/src/scss/features/_top.scss
@@ -132,10 +132,9 @@
 		display: block;
 		border: 0;
 		margin: 16px auto;
-		background-size: contain;
+		background-size: 100% 100%; // Edge SVG background clipped when scaled https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4705340/
 		background-position: 50%;
 		background-repeat: no-repeat;
-		background-size: 100% 100%; // Edge SVG background clipped when scaled https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4705340/
 
 		@include oGridRespondTo('S') {
 			@include oHeaderLogoSize('S');


### PR DESCRIPTION
Edge contained SVG backgrounds are clipped when scaled.
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4705340/

This helps the masthead but not other potential cases of clipping.

Issue with screenshots: https://github.com/Financial-Times/o-header/issues/276