### PR TITLE
Use aria-current to identify current nav page

### DIFF
--- a/demos/src/grid-demo.mustache
+++ b/demos/src/grid-demo.mustache
@@ -79,7 +79,7 @@
 		<ul class="o-header__nav-list">
 			{{#mobile}}
 			<li class="o-header__nav-item">
-				<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+				<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 			</li>
 			{{/mobile}}
 		</ul>
@@ -90,7 +90,7 @@
 			<ul class="o-header__nav-list o-header__nav-list--left">
 				{{#desktop}}
 				<li class="o-header__nav-item">
-					<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}} id="o-header-link-{{index}}" {{#hasMega}}aria-controls="o-header-mega-{{index}}"{{/hasMega}}>{{name}}</a>
+					<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}} id="o-header-link-{{index}}" {{#hasMega}}aria-controls="o-header-mega-{{index}}"{{/hasMega}}>{{name}}</a>
 				</li>
 				{{/desktop}}
 			</ul>
@@ -134,7 +134,7 @@
 		{{#editions}}
 		<nav class="o-header__drawer-editions" aria-label="Edition switcher">
 			{{#editions.current}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-selected="true">{{name}} Edition</a>
+			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-current="page">{{name}} Edition</a>
 			{{/editions.current}}
 			{{#editions.others}}
 			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}">{{name}} Edition</a>
@@ -162,7 +162,7 @@
 						<li class="o-header__drawer-menu-item {{#divide}}o-header__drawer-menu-item--divide{{/divide}}">
 							{{#hasChildren}}
 								<div class="o-header__drawer-menu-toggle-wrapper">
-									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 									<button class="o-header__drawer-menu-toggle o-header__drawer-menu-toggle--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" aria-controls="o-header-drawer-child-{{index}}">
 										Show more {{name}} links
 									</button>
@@ -170,13 +170,13 @@
 								<ul class="o-header__drawer-menu-list o-header__drawer-menu-list--child" id="o-header-drawer-child-{{index}}">
 									{{#children}}
 									<li class="o-header__drawer-menu-item">
-										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 									</li>
 									{{/children}}
 								</ul>
 							{{/hasChildren}}
 							{{^hasChildren}}
-								<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{variation}} o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+								<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{variation}} o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 							{{/hasChildren}}
 						</li>
 						{{/items}}

--- a/demos/src/header.mustache
+++ b/demos/src/header.mustache
@@ -79,7 +79,7 @@
 		<ul class="o-header__nav-list">
 			{{#mobile}}
 			<li class="o-header__nav-item">
-				<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+				<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 			</li>
 			{{/mobile}}
 		</ul>
@@ -90,7 +90,7 @@
 			<ul class="o-header__nav-list o-header__nav-list--left">
 				{{#desktop}}
 				<li class="o-header__nav-item">
-					<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}} id="o-header-link-{{index}}" {{#hasMega}}aria-controls="o-header-mega-{{index}}"{{/hasMega}}>{{name}}</a>
+					<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}} id="o-header-link-{{index}}" {{#hasMega}}aria-controls="o-header-mega-{{index}}"{{/hasMega}}>{{name}}</a>
 				</li>
 				{{/desktop}}
 			</ul>
@@ -134,7 +134,7 @@
 		{{#editions}}
 		<nav class="o-header__drawer-editions" aria-label="Edition switcher">
 			{{#editions.current}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-selected="true">{{name}} Edition</a>
+			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-current="page">{{name}} Edition</a>
 			{{/editions.current}}
 			{{#editions.others}}
 			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}">{{name}} Edition</a>
@@ -162,7 +162,7 @@
 						<li class="o-header__drawer-menu-item {{#divide}}o-header__drawer-menu-item--divide{{/divide}}">
 							{{#hasChildren}}
 								<div class="o-header__drawer-menu-toggle-wrapper">
-									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 									<button class="o-header__drawer-menu-toggle o-header__drawer-menu-toggle--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" aria-controls="o-header-drawer-child-{{index}}">
 										Show more {{name}} links
 									</button>
@@ -170,13 +170,13 @@
 								<ul class="o-header__drawer-menu-list o-header__drawer-menu-list--child" id="o-header-drawer-child-{{index}}">
 									{{#children}}
 									<li class="o-header__drawer-menu-item">
-										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 									</li>
 									{{/children}}
 								</ul>
 							{{/hasChildren}}
 							{{^hasChildren}}
-								<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{variation}} o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+								<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{variation}} o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 							{{/hasChildren}}
 						</li>
 						{{/items}}

--- a/demos/src/mega-menu.mustache
+++ b/demos/src/mega-menu.mustache
@@ -4,7 +4,7 @@
 		<ul class="o-header__nav-list">
 			{{#mobile}}
 			<li class="o-header__nav-item">
-				<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+				<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 			</li>
 			{{/mobile}}
 		</ul>
@@ -15,7 +15,7 @@
 			<ul class="o-header__nav-list o-header__nav-list--left">
 				{{#desktop}}
 				<li class="o-header__nav-item">
-					<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}} id="o-header-link-{{index}}" {{#hasMega}}aria-controls="o-header-mega-{{index}}"{{/hasMega}}>{{name}}</a>
+					<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}} id="o-header-link-{{index}}" {{#hasMega}}aria-controls="o-header-mega-{{index}}"{{/hasMega}}>{{name}}</a>
 					{{#hasMega}}
 					<div class="o-header__mega" id="o-header-mega-{{index}}" role="group" aria-labelledby="o-header-link-{{index}}" data-o-header-mega>
 						<div class="o-header__container">
@@ -28,7 +28,7 @@
 										<ul class="o-header__mega-list">
 											{{#subsections}}
 											<li class="o-header__mega-item">
-												<a class="o-header__mega-link" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>
+												<a class="o-header__mega-link" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>
 													{{name}}
 												</a>
 											</li>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -79,7 +79,7 @@
 		<ul class="o-header__nav-list">
 			{{#mobile}}
 			<li class="o-header__nav-item">
-				<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+				<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 			</li>
 			{{/mobile}}
 		</ul>
@@ -90,7 +90,7 @@
 			<ul class="o-header__nav-list o-header__nav-list--left">
 				{{#desktop}}
 				<li class="o-header__nav-item">
-					<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}" {{#hasMega}}aria-controls="o-header-mega-{{index}}"{{/hasMega}}>{{name}}</a>
+					<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}" {{#hasMega}}aria-controls="o-header-mega-{{index}}"{{/hasMega}}>{{name}}</a>
 				</li>
 				{{/desktop}}
 			</ul>
@@ -134,7 +134,7 @@
 		{{#editions}}
 		<nav class="o-header__drawer-editions" aria-label="Edition switcher">
 			{{#editions.current}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-selected="true">{{name}} Edition</a>
+			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-current="page">{{name}} Edition</a>
 			{{/editions.current}}
 			{{#editions.others}}
 			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}">{{name}} Edition</a>
@@ -162,7 +162,7 @@
 						<li class="o-header__drawer-menu-item {{#divide}}o-header__drawer-menu-item--divide{{/divide}}">
 							{{#hasChildren}}
 								<div class="o-header__drawer-menu-toggle-wrapper">
-									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 									<button class="o-header__drawer-menu-toggle o-header__drawer-menu-toggle--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" aria-controls="o-header-drawer-child-{{index}}">
 										Show more {{name}} links
 									</button>
@@ -170,13 +170,13 @@
 								<ul class="o-header__drawer-menu-list o-header__drawer-menu-list--child" id="o-header-drawer-child-{{index}}">
 									{{#children}}
 									<li class="o-header__drawer-menu-item">
-										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 									</li>
 									{{/children}}
 								</ul>
 							{{/hasChildren}}
 							{{^hasChildren}}
-								<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{variation}} o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+								<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{variation}} o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 							{{/hasChildren}}
 						</li>
 						{{/items}}

--- a/demos/src/simple-header.mustache
+++ b/demos/src/simple-header.mustache
@@ -66,7 +66,7 @@
 		{{#editions}}
 		<nav class="o-header__drawer-editions" aria-label="Edition switcher">
 			{{#editions.current}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-selected="true">{{name}} Edition</a>
+			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-current="page">{{name}} Edition</a>
 			{{/editions.current}}
 			{{#editions.others}}
 			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}">{{name}} Edition</a>
@@ -94,7 +94,7 @@
 						<li class="o-header__drawer-menu-item {{#divide}}o-header__drawer-menu-item--divide{{/divide}}">
 							{{#hasChildren}}
 								<div class="o-header__drawer-menu-toggle-wrapper">
-									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 									<button class="o-header__drawer-menu-toggle o-header__drawer-menu-toggle--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" aria-controls="o-header-drawer-child-{{index}}">
 										Show more {{name}} links
 									</button>
@@ -102,13 +102,13 @@
 								<ul class="o-header__drawer-menu-list o-header__drawer-menu-list--child" id="o-header-drawer-child-{{index}}">
 									{{#children}}
 									<li class="o-header__drawer-menu-item">
-										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 									</li>
 									{{/children}}
 								</ul>
 							{{/hasChildren}}
 							{{^hasChildren}}
-								<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{variation}} o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+								<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{variation}} o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 							{{/hasChildren}}
 						</li>
 						{{/items}}

--- a/demos/src/sticky-header.mustache
+++ b/demos/src/sticky-header.mustache
@@ -23,7 +23,7 @@
 							<ul class="o-header__nav-list o-header__nav-list--left">
 								{{#desktop}}
 								<li class="o-header__nav-item">
-									<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}} tabindex="-1">{{name}}</a>
+									<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}} tabindex="-1">{{name}}</a>
 								</li>
 								{{/desktop}}
 							</ul>
@@ -97,7 +97,7 @@
 		{{#editions}}
 		<nav class="o-header__drawer-editions" aria-label="Edition switcher">
 			{{#editions.current}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-selected="true">{{name}} Edition</a>
+			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-current="page">{{name}} Edition</a>
 			{{/editions.current}}
 			{{#editions.others}}
 			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}">{{name}} Edition</a>
@@ -125,7 +125,7 @@
 						<li class="o-header__drawer-menu-item {{#divide}}o-header__drawer-menu-item--divide{{/divide}}">
 							{{#hasChildren}}
 								<div class="o-header__drawer-menu-toggle-wrapper">
-									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 									<button class="o-header__drawer-menu-toggle o-header__drawer-menu-toggle--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" aria-controls="o-header-drawer-child-{{index}}">
 										Show more {{name}} links
 									</button>
@@ -133,13 +133,13 @@
 								<ul class="o-header__drawer-menu-list o-header__drawer-menu-list--child" id="o-header-drawer-child-{{index}}">
 									{{#children}}
 									<li class="o-header__drawer-menu-item">
-										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 									</li>
 									{{/children}}
 								</ul>
 							{{/hasChildren}}
 							{{^hasChildren}}
-								<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{variation}} o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+								<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{variation}} o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 							{{/hasChildren}}
 						</li>
 						{{/items}}

--- a/demos/src/subbrand.mustache
+++ b/demos/src/subbrand.mustache
@@ -62,7 +62,7 @@
 		{{#editions}}
 		<nav class="o-header__drawer-editions" aria-label="Edition switcher">
 			{{#editions.current}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-selected="true">{{name}} Edition</a>
+			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-current="page">{{name}} Edition</a>
 			{{/editions.current}}
 			{{#editions.others}}
 			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}">{{name}} Edition</a>
@@ -90,7 +90,7 @@
 						<li class="o-header__drawer-menu-item {{#divide}}o-header__drawer-menu-item--divide{{/divide}}">
 							{{#hasChildren}}
 								<div class="o-header__drawer-menu-toggle-wrapper">
-									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 									<button class="o-header__drawer-menu-toggle o-header__drawer-menu-toggle--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" aria-controls="o-header-drawer-child-{{index}}">
 										Show more {{name}} links
 									</button>
@@ -98,13 +98,13 @@
 								<ul class="o-header__drawer-menu-list o-header__drawer-menu-list--child" id="o-header-drawer-child-{{index}}">
 									{{#children}}
 									<li class="o-header__drawer-menu-item">
-										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 									</li>
 									{{/children}}
 								</ul>
 							{{/hasChildren}}
 							{{^hasChildren}}
-								<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{variation}} o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+								<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{variation}} o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 							{{/hasChildren}}
 						</li>
 						{{/items}}
@@ -160,7 +160,7 @@
 						{{/currentNav.ancestors}}
 						{{#currentNav}}
 						<li class="o-header__subnav-item">
-							<a class="o-header__subnav-link" href="{{href}}" aria-selected="true" aria-label="Current page">
+							<a class="o-header__subnav-link" href="{{href}}" aria-current="page" aria-label="Current page">
 								{{name}}
 							</a>
 						</li>

--- a/demos/src/subnav.mustache
+++ b/demos/src/subnav.mustache
@@ -4,7 +4,7 @@
 		<ul class="o-header__nav-list">
 			{{#mobile}}
 			<li class="o-header__nav-item">
-				<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+				<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 			</li>
 			{{/mobile}}
 		</ul>
@@ -15,7 +15,7 @@
 			<ul class="o-header__nav-list o-header__nav-list--left">
 				{{#desktop}}
 				<li class="o-header__nav-item">
-					<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}} id="o-header-link-{{index}}">{{name}}</a>
+					<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}} id="o-header-link-{{index}}">{{name}}</a>
 				</li>
 				{{/desktop}}
 			</ul>
@@ -57,7 +57,7 @@
 							{{/currentNav.ancestors}}
 							{{#currentNav}}
 							<li class="o-header__subnav-item">
-								<a class="o-header__subnav-link" href="{{href}}" aria-selected="true" aria-label="Current page">
+								<a class="o-header__subnav-link" href="{{href}}" aria-current="page" aria-label="Current page">
 									{{name}}
 								</a>
 							</li>

--- a/demos/src/transparent-header.mustache
+++ b/demos/src/transparent-header.mustache
@@ -54,7 +54,7 @@
 			<ul class="o-header__nav-list o-header__nav-list--left">
 				{{#desktop}}
 				<li class="o-header__nav-item">
-					<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}} id="o-header-link-{{index}}" {{#hasMega}}aria-controls="o-header-mega-{{index}}"{{/hasMega}}>{{name}}</a>
+					<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}} id="o-header-link-{{index}}" {{#hasMega}}aria-controls="o-header-mega-{{index}}"{{/hasMega}}>{{name}}</a>
 					{{#hasMega}}
 					<div class="o-header__mega" id="o-header-mega-{{index}}" role="group" aria-labelledby="o-header-link-{{index}}" data-o-header-mega>
 						<div class="o-header__container">
@@ -67,7 +67,7 @@
 										<ul class="o-header__mega-list">
 											{{#subsections}}
 											<li class="o-header__mega-item">
-												<a class="o-header__mega-link" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>
+												<a class="o-header__mega-link" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>
 													{{name}}
 												</a>
 											</li>
@@ -137,7 +137,7 @@
 		{{#editions}}
 		<nav class="o-header__drawer-editions" aria-label="Edition switcher">
 			{{#editions.current}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-selected="true">{{name}} Edition</a>
+			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-current="page">{{name}} Edition</a>
 			{{/editions.current}}
 			{{#editions.others}}
 			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}">{{name}} Edition</a>
@@ -165,7 +165,7 @@
 						<li class="o-header__drawer-menu-item {{#divide}}o-header__drawer-menu-item--divide{{/divide}}">
 							{{#hasChildren}}
 								<div class="o-header__drawer-menu-toggle-wrapper">
-									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 									<button class="o-header__drawer-menu-toggle o-header__drawer-menu-toggle--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" aria-controls="o-header-drawer-child-{{index}}">
 										Show more {{name}} links
 									</button>
@@ -173,13 +173,13 @@
 								<ul class="o-header__drawer-menu-list o-header__drawer-menu-list--child" id="o-header-drawer-child-{{index}}">
 									{{#children}}
 									<li class="o-header__drawer-menu-item">
-										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 									</li>
 									{{/children}}
 								</ul>
 							{{/hasChildren}}
 							{{^hasChildren}}
-								<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{variation}} o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-selected="true"{{/selected}}>{{name}}</a>
+								<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{variation}} o-header__drawer-menu-link--{{#selected}}selected{{/selected}}{{^selected}}unselected{{/selected}}" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
 							{{/hasChildren}}
 						</li>
 						{{/items}}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -40,7 +40,8 @@
 	}
 
 	&--highlight,
-	&[aria-selected="true"] {
+	&[aria-selected="true"], // deprecated
+	&[aria-current] {
 		color: oColorsGetColorFor('o-header-link-highlight', 'text');
 	}
 }
@@ -66,7 +67,8 @@
 	}
 
 	&--highlight:after,
-	&[aria-selected="true"]:after {
+	&[aria-selected="true"]:after, // deprecated
+	&[aria-current]:after {
 		background-color: oColorsGetColorFor('o-header-link-highlight', 'text');
 	}
 }

--- a/src/scss/features/_drawer.scss
+++ b/src/scss/features/_drawer.scss
@@ -135,7 +135,8 @@
 			margin-left: 0;
 		}
 
-		&[aria-selected="true"] {
+		&[aria-selected="true"], // deprecated
+		&[aria-current] {
 			@include oColorsFor(o-header-drawer-editions-link-highlight, text);
 			font-weight: 600;
 			text-decoration: none;

--- a/src/scss/features/_transparent.scss
+++ b/src/scss/features/_transparent.scss
@@ -39,12 +39,14 @@
 			}
 
 			&--highlight,
-			&[aria-selected="true"] {
+			&[aria-selected="true"], // deprecated
+			&[aria-current] {
 				color: oColorsGetColorFor('o-header-transparent-link-highlight', 'text');
 			}
 
 			&--highlight:after,
-			&[aria-selected="true"]:after {
+			&[aria-selected="true"]:after, // deprecated
+			&[aria-current]:after {
 				background-color: oColorsGetColorFor('o-header-transparent-link-highlight', 'text');
 			}
 		}


### PR DESCRIPTION
The last Digital Accessibility Centre audit report (28/02/2018) picked up on the fact that the navigation links use `aria-selected="true"` to indicate the current page/section, when this attribute is not supported on links.

This PR adds support for using `aria-current` (with any value) instead, and deprecates `aria-selected="true"`.

The demos use the value of `page` for `aria-current`, but the value should only be `page` when you are actually on that page. When on a page within that section, the value can just be `true`.