### PR TITLE
Show logos in Windows high contrast mode

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -126,6 +126,16 @@
 	background-image: url($base-url + $logo-name + "?source=o-header&tint=%23#{$color},%23#{$color}&format=svg");
 	background-image: url($base-url + $logo-name + "?source=o-header&tint=%23#{$color},%23#{$color}&format=png&width=#{$fallback-width}") \9;
 	// sass-lint:enable no-duplicate-properties
+
+	// sass-lint:disable no-vendor-prefixes
+	@media screen and (-ms-high-contrast: active) {
+		background-image: url($base-url + $logo-name + "?source=o-header&tint=%23ffffff,%23ffffff&format=svg");
+	}
+
+	@media screen and (-ms-high-contrast: black-on-white) {
+		background-image: url($base-url + $logo-name + "?source=o-header&tint=%23000000,%23000000&format=svg");
+	}
+	// sass-lint:enable no-vendor-prefixes
 }
 
 /// Applies styles to hide an element accessibly,


### PR DESCRIPTION
Apply the changes from https://github.com/Financial-Times/o-icons/pull/68 to o-header.