### PR TITLE
Add toggleTabbing function(to solve a DAC issue)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -77,7 +77,9 @@ function addDrawerToggles (drawerEl) {
 	function toggleCallback (state, e) {
 		if (state === 'close') {
 			toggleTabbing(drawerEl, false);
+			
 			handleClose.removeEvents();
+
 			openingControl.focus();
 		} else {
 			toggleTabbing(drawerEl, true);

--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -76,10 +76,12 @@ function addDrawerToggles (drawerEl) {
 
 	function toggleCallback (state, e) {
 		if (state === 'close') {
+			toggleTabbing(drawerEl, false);
 			handleClose.removeEvents();
-
 			openingControl.focus();
 		} else {
+			toggleTabbing(drawerEl, true);
+
 			// don't capture the initial click or accidental double taps etc.
 			// we could use transitionend but scoping is tricky and it needs prefixing and...
 			setTimeout(handleClose.addEvents, LISTEN_DELAY);
@@ -142,11 +144,28 @@ function addSubmenuToggles (drawerEl) {
 	});
 }
 
+// This function is to solve accessibility issue
+// when o-header-drawer is closed => tabbing is disabled.
+// when o-header-drawer is open => tabbing is enabled.
+function toggleTabbing (drawerEl, isEnabled) {
+	const allFocusable = drawerEl.querySelectorAll('a, button, input, select');
+	if (isEnabled) {
+		allFocusable.forEach(el => {
+			el.removeAttribute('tabindex');
+		});
+	} else {
+		allFocusable.forEach(el => {
+			el.setAttribute('tabindex', '-1');
+		});
+	}
+}
+
 function init () {
 	const drawerEl = document.body.querySelector('[data-o-header-drawer]');
 	if (!drawerEl) {
 		return;
 	}
+	toggleTabbing(drawerEl, false);
 	addSubmenuToggles(drawerEl);
 	addDrawerToggles(drawerEl);
 

--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -77,7 +77,7 @@ function addDrawerToggles (drawerEl) {
 	function toggleCallback (state, e) {
 		if (state === 'close') {
 			toggleTabbing(drawerEl, false);
-			
+
 			handleClose.removeEvents();
 
 			openingControl.focus();


### PR DESCRIPTION
**Issue ID: DAC_TECH_ TabOrder_02**
This is to solve one of the DAC issues.
o-header drawer menu elements can still accept keyboard focus when the menu is off-screen. This means people can get lost when tabbing through the page.