### PR TITLE
Make subnav items inline-block so their height expands to match their contents.

### DIFF
--- a/src/scss/features/_subnav.scss
+++ b/src/scss/features/_subnav.scss
@@ -74,7 +74,7 @@
 
 		.o-header__subnav-item {
 			position: relative;
-			display: inline;
+			display: inline-block;
 			padding-left: 6px;
 
 			&:first-child {


### PR DESCRIPTION
Improves tooltip positioning.

Before:
![image](https://user-images.githubusercontent.com/471250/38556370-5b971d12-3cc1-11e8-9c37-0586421f8802.png)

After:
![image](https://user-images.githubusercontent.com/471250/38556387-6c286212-3cc1-11e8-8873-a1ec2efa0a85.png)
