### PR TITLE
Scroll into view

### DIFF
--- a/demos/src/subnav.json
+++ b/demos/src/subnav.json
@@ -470,12 +470,12 @@
 			},
 			{
 				"name": "US Politics & Policy",
-				"href": "#"
+				"href": "#",
+				"selected": true
 			},
 			{
 				"name": "US Companies",
-				"href": "#",
-				"selected": true
+				"href": "#"
 			}
 		]
 	}

--- a/demos/src/subnav.json
+++ b/demos/src/subnav.json
@@ -474,7 +474,8 @@
 			},
 			{
 				"name": "US Companies",
-				"href": "#"
+				"href": "#",
+				"selected": true
 			}
 		]
 	}

--- a/demos/src/subnav.mustache
+++ b/demos/src/subnav.mustache
@@ -4,7 +4,7 @@
 		<ul class="o-header__nav-list">
 			{{#mobile}}
 			<li class="o-header__nav-item">
-				<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}}>{{name}}</a>
+				<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}">{{name}}</a>
 			</li>
 			{{/mobile}}
 		</ul>
@@ -15,7 +15,7 @@
 			<ul class="o-header__nav-list o-header__nav-list--left">
 				{{#desktop}}
 				<li class="o-header__nav-item">
-					<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}" {{#selected}}aria-label="Current page" aria-current="page"{{/selected}} id="o-header-link-{{index}}">{{name}}</a>
+					<a class="o-header__nav-link o-header__nav-link--primary" href="{{href}}"  id="o-header-link-{{index}}">{{name}}</a>
 				</li>
 				{{/desktop}}
 			</ul>
@@ -57,7 +57,7 @@
 							{{/currentNav.ancestors}}
 							{{#currentNav}}
 							<li class="o-header__subnav-item">
-								<a class="o-header__subnav-link" href="{{href}}" aria-current="page" aria-label="Current page">
+								<a class="o-header__subnav-link" href="{{href}}" >
 									{{name}}
 								</a>
 							</li>
@@ -67,7 +67,7 @@
 						<ul class="o-header__subnav-list o-header__subnav-list--children" aria-label="Subsections">
 							{{#currentNav.children}}
 							<li class="o-header__subnav-item">
-								<a class="o-header__subnav-link" href="{{href}}">
+								<a class="o-header__subnav-link" href="{{href}}" {{#selected}}aria-current="page" aria-label="Current page"{{/selected}}>
 									{{name}}
 								</a>
 							</li>
@@ -82,4 +82,3 @@
 	</div>
 	{{/subnav}}
 </header>
-

--- a/src/js/header.js
+++ b/src/js/header.js
@@ -27,10 +27,6 @@ class Header {
 
 		this.headerEl.removeAttribute('data-o-header--no-js');
 		this.headerEl.setAttribute('data-o-header--js', '');
-
-		setTimeout(() => {
-			document.querySelector('[aria-current]').scrollIntoView();
-		}, 1000);
 	}
 
 	static init (rootEl) {

--- a/src/js/header.js
+++ b/src/js/header.js
@@ -27,6 +27,10 @@ class Header {
 
 		this.headerEl.removeAttribute('data-o-header--no-js');
 		this.headerEl.setAttribute('data-o-header--js', '');
+
+		setTimeout(() => {
+			document.querySelector('[aria-current]').scrollIntoView();
+		}, 1000);
 	}
 
 	static init (rootEl) {

--- a/src/js/subnav.js
+++ b/src/js/subnav.js
@@ -47,6 +47,15 @@ function init(headerEl) {
 		scrollable();
 	}
 
+	function scrollToCurrent() {
+		let currentSelectionEnd = wrapper.querySelector('[aria-current]').getBoundingClientRect().right;
+		let wrapperWidth = wrapper.getBoundingClientRect().width;
+
+		if (currentSelectionEnd > wrapperWidth) {
+			wrapper.scrollTo(currentSelectionEnd, 0);
+		}
+	}
+
 	wrapper.addEventListener('scroll', oUtils.throttle(scrollable, 100));
 	window.addEventListener('oViewport.resize', scrollable);
 
@@ -55,6 +64,7 @@ function init(headerEl) {
 	});
 
 	scrollable();
+	scrollToCurrent();
 }
 
 export default { init };


### PR DESCRIPTION
On mobile viewports, the selected page would not be in view if it was out of the viewport to begin with.

Now it scrolls the selection into view:

![scroll](https://user-images.githubusercontent.com/16777943/40172245-b672ebbe-59c5-11e8-9748-ed9ce5a3f84a.gif)
