### PR TITLE
check for aria-current node

### DIFF
--- a/src/js/subnav.js
+++ b/src/js/subnav.js
@@ -48,7 +48,10 @@ function init(headerEl) {
 	}
 
 	function scrollToCurrent() {
-		let currentSelectionEnd = wrapper.querySelector('[aria-current]').getBoundingClientRect().right;
+		let currentSelectionEnd =
+			wrapper.querySelector('[aria-current]')
+			&& wrapper.querySelector('[aria-current]').getBoundingClientRect().right;
+
 		let wrapperWidth = wrapper.getBoundingClientRect().width;
 
 		if (currentSelectionEnd > wrapperWidth) {

--- a/src/js/subnav.js
+++ b/src/js/subnav.js
@@ -48,14 +48,16 @@ function init(headerEl) {
 	}
 
 	function scrollToCurrent() {
-		let currentSelectionEnd =
-			wrapper.querySelector('[aria-current]')
-			&& wrapper.querySelector('[aria-current]').getBoundingClientRect().right;
+		const currentSelection = wrapper.querySelector('[aria-current]');
 
-		let wrapperWidth = wrapper.getBoundingClientRect().width;
+		if(currentSelection) {
+			let currentSelectionEnd = wrapper.querySelector('[aria-current]').getBoundingClientRect().right;
 
-		if (currentSelectionEnd > wrapperWidth) {
-			wrapper.scrollTo(currentSelectionEnd, 0);
+			let wrapperWidth = wrapper.getBoundingClientRect().width;
+
+			if (currentSelectionEnd > wrapperWidth) {
+				wrapper.scrollTo(currentSelectionEnd, 0);
+			}
 		}
 	}
 


### PR DESCRIPTION
When a subnav doesn't have a link with an `aria-selected` property, we were getting `Uncaught TypeError: Cannot read property 'getBoundingClientRect' of null` errors which was causing our JS to blow up on stream pages with a subnav. 

This PR adds a check for the existence of that node.