### PR TITLE
Remove PNG fallback for SVG background-image

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -122,10 +122,7 @@
 @mixin oHeaderBrandImage($logo-name, $color, $fallback-width) {
 	$base-url: "#{$o-header-image-base-url}/#{$o-header-image-service-version}/images/raw/ftlogo:";
 	$color: str-slice(ie-hex-str($color), 4);
-	// sass-lint:disable no-duplicate-properties
 	background-image: url($base-url + $logo-name + "?source=o-header&tint=%23#{$color},%23#{$color}&format=svg");
-	background-image: url($base-url + $logo-name + "?source=o-header&tint=%23#{$color},%23#{$color}&format=png&width=#{$fallback-width}") \9;
-	// sass-lint:enable no-duplicate-properties
 
 	// sass-lint:disable no-vendor-prefixes
 	@media screen and (-ms-high-contrast: active) {


### PR DESCRIPTION
We no longer actively support IE8 and can remove this fallback.