### PR TITLE
Update`o-brand`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
 	"name": "o-header",
 	"dependencies": {
 		"o-colors": "^4.0.1",
-		"o-brand": "^2.1.1",
+		"o-brand": ">=2.2.0 <4",
 		"o-buttons": "^5.0.0",
 		"o-grid": "^4.2.0",
 		"o-icons": ">=4.4.2 <6",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
 	"name": "o-header",
 	"dependencies": {
 		"o-colors": "^4.0.1",
-		"o-brand": "^2.0.2",
+		"o-brand": "^2.1.1",
 		"o-buttons": "^5.0.0",
 		"o-grid": "^4.2.0",
 		"o-icons": ">=4.4.2 <6",

--- a/src/js/subnav.js
+++ b/src/js/subnav.js
@@ -51,7 +51,7 @@ function init(headerEl) {
 		const currentSelection = wrapper.querySelector('[aria-current]');
 
 		if(currentSelection) {
-			let currentSelectionEnd = wrapper.querySelector('[aria-current]').getBoundingClientRect().right;
+			let currentSelectionEnd = currentSelection.getBoundingClientRect().right;
 
 			let wrapperWidth = wrapper.getBoundingClientRect().width;
 

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -1,14 +1,13 @@
 @mixin oHeaderBase() {
-	@include oBrandConfigureFor('o-header') {
-		.o-header {
-			color: oBrandGet('header-text');
-			background-color: oBrandGet('header-background');
-		}
+	.o-header {
+		color: _oHeaderGet('header-text');
+		background-color: _oHeaderGet('header-background');
+	}
 
-		.o-header__row {
-			border-bottom: 1px solid oBrandGet('header-border');
-		}
-	};
+	.o-header__row {
+		border-bottom: 1px solid _oHeaderGet('header-border');
+	}
+
 
 	.o-header__container {
 		@include oGridContainer();

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -68,16 +68,16 @@
 		)
 	),
 	'supports-variants': (
-		'transparent': true,
-		'subnav': true,
-		'search': true,
-		'nav': true,
-		'anon': true,
-		'drawer': true,
-		'megamenu': true,
-		'sticky': true,
-		'simple': true,
-		'subbrand': true
+		'transparent',
+		'subnav',
+		'search',
+		'nav',
+		'anon',
+		'drawer',
+		'megamenu',
+		'sticky',
+		'simple',
+		'subbrand'
 	)
 ));
 
@@ -130,14 +130,14 @@
 		drawer-unselected-toggle-background: oColorsGetPaletteColor('slate-white-15')
 	),
 	'supports-variants': (
-		'subnav': true,
-		'search': true,
-		'nav': true,
-		'anon': true,
-		'drawer': true,
-		'megamenu': true,
-		'sticky': true,
-		'simple': true,
-		'subbrand': true
+		'subnav',
+		'search',
+		'nav',
+		'anon',
+		'drawer',
+		'megamenu',
+		'sticky',
+		'simple',
+		'subbrand'
 	)
 ));

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -48,7 +48,11 @@
 		drawer-unselected-toggle-text: oColorsGetPaletteColor('teal-40'),
 		drawer-unselected-toggle-background: oColorsGetPaletteColor('black-10'),
 		'transparent': (
-			transparency: oColorsGetPaletteColor('white'),
+			header-border: rgba(oColorsGetPaletteColor('white'), 0.4),
+			header-background: oColorsGetPaletteColor('transparent'),
+			header-icon: oColorsGetPaletteColor('white'),
+			link-hover-text: oColorsGetPaletteColor('white'),
+			link-highlight-text: oColorsGetPaletteColor('white'),
 		)
 	),
 	'settings': (
@@ -64,7 +68,6 @@
 		header-icon: oColorsGetPaletteColor('black-80'),
 		link-hover-text: oColorsGetPaletteColor('black-80'),
 		link-highlight-text: oColorsGetPaletteColor('slate'),
-		transparency: oColorsGetPaletteColor('white'),
 		search-border: oColorsGetPaletteColor('teal-40'),
 		search-background: oColorsGetPaletteColor('black-20'),
 		mega-menu-background: oColorsGetPaletteColor('white-60'),
@@ -105,7 +108,5 @@
 		drawer-unselected-toggle-text: oColorsGetPaletteColor('slate'),
 		drawer-unselected-toggle-background: oColorsGetPaletteColor('slate-white-15')
 	),
-	'settings': (
-		'transparent': false
-	)
+	'settings': ()
 ));

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -1,3 +1,15 @@
+/// Helper `o-brand` wrapper.
+/// @access private
+@function _oHeaderGet($variables, $from: null) {
+	@return oBrandGet($component: 'o-header',  $variables: $variables, $from: $from);
+}
+
+/// Helper `o-brand` wrapper.
+/// @access private
+@function _oHeaderSupports($variant) {
+	@return oBrandSupportsVariant($component: 'o-header', $variant: $variant);
+}
+
 @include oBrandDefine('o-header', 'master', (
 	'variables': (
 		header-text: oColorsGetPaletteColor('black-80'),
@@ -55,8 +67,17 @@
 			link-highlight-text: oColorsGetPaletteColor('white'),
 		)
 	),
-	'settings': (
-		'transparent': true
+	'supports-variants': (
+		'transparent': true,
+		'subnav': true,
+		'search': true,
+		'nav': true,
+		'anon': true,
+		'drawer': true,
+		'megamenu': true,
+		'sticky': true,
+		'simple': true,
+		'subbrand': true
 	)
 ));
 
@@ -108,5 +129,15 @@
 		drawer-unselected-toggle-text: oColorsGetPaletteColor('slate'),
 		drawer-unselected-toggle-background: oColorsGetPaletteColor('slate-white-15')
 	),
-	'settings': ()
+	'supports-variants': (
+		'subnav': true,
+		'search': true,
+		'nav': true,
+		'anon': true,
+		'drawer': true,
+		'megamenu': true,
+		'sticky': true,
+		'simple': true,
+		'subbrand': true
+	)
 ));

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -7,8 +7,6 @@
 		link-hover-text: oColorsGetPaletteColor('black-80'),
 		link-highlight-text: oColorsGetPaletteColor('teal-40'),
 
-		transparency: oColorsGetPaletteColor('white'),
-
 		search-border: oColorsGetPaletteColor('teal-40'),
 		search-background: oColorsGetPaletteColor('black-20'),
 
@@ -48,7 +46,10 @@
 		drawer-selected-toggle-text: oColorsGetPaletteColor('white'),
 		drawer-selected-toggle-background: oColorsGetPaletteColor('white'),
 		drawer-unselected-toggle-text: oColorsGetPaletteColor('teal-40'),
-		drawer-unselected-toggle-background: oColorsGetPaletteColor('black-10')
+		drawer-unselected-toggle-background: oColorsGetPaletteColor('black-10'),
+		'transparent': (
+			transparency: oColorsGetPaletteColor('white'),
+		)
 	),
 	'settings': (
 		'transparent': true

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -10,19 +10,26 @@
 		@include oHeaderTop;
 	}
 
-	// By default, output all rows
+	// By default, output all features which are supported by the brand (see _brand.scss)
 	@if $features == '' {
 		@each $feature in $_o-header-features {
-			@include _oHeaderGetFeatureMixin($feature);
+			@if _oHeaderSupports($feature) {
+				@include _oHeaderGetFeatureMixin($feature);
+			}
 		}
 	} @else {
 		@each $feature in $features {
-			@if index($_o-header-features, $feature) != null {
-				@include _oHeaderGetFeatureMixin($feature);
-			} @else {
+			// Check the feature exists.
+			@if index($_o-header-features, $feature) == null {
 				@error "There is no feature '#{$feature}' available in o-header please use one of "
 				+ "the following: #{$_o-header-features}";
 			}
+			// Warn if the current brand does not explicitly support the requested feature.
+			@if not _oHeaderSupports($feature) {
+				@warn 'The "#{$feature}" feature of "o-header" is not explicitly supported for the app\'s brand and may lead to unexpected results. Please contact Origami if you would like official support for this feature.';
+			}
+			// Output feature.
+			@include _oHeaderGetFeatureMixin($feature);
 		}
 	}
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -25,9 +25,7 @@
 	} @else if $feature == 'subbrand' {
 		@include oHeaderSubbrand;
 	} @else if $feature == 'transparent' {
-		@include oBrandConfigureFor('o-header', 'transparent') {
-			@include oHeaderTransparent;
-		};
+		@include oHeaderTransparent;
 	}
 }
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -30,50 +30,46 @@
 
 /// Base styles for header links
 @mixin oHeaderLink() {
-	@include oBrandConfigureFor('o-header')  {
-		color: inherit;
-		text-decoration: none;
-		border: 0;
+	color: inherit;
+	text-decoration: none;
+	border: 0;
 
-		&:hover {
-			color: oBrandGet('link-hover-text');
-		}
+	&:hover {
+		color: _oHeaderGet('link-hover-text');
+	}
 
-		&--highlight,
-		&[aria-selected="true"], // deprecated
-		&[aria-current] {
-			color: oBrandGet('link-highlight-text');
-		}
-	};
+	&--highlight,
+	&[aria-selected="true"], // deprecated
+	&[aria-current] {
+		color: _oHeaderGet('link-highlight-text');
+	}
 }
 
 /// More visually decorated link styles
 @mixin oHeaderFancyLink() {
-	@include oBrandConfigureFor('o-header') {
-		position: relative;
-		display: block;
-		padding: $_o-header-padding-y 0;
-		white-space: nowrap;
+	position: relative;
+	display: block;
+	padding: $_o-header-padding-y 0;
+	white-space: nowrap;
 
-		&:after {
-			content: '';
-			position: absolute;
-			bottom: 0;
-			left: 0;
-			width: 100%;
-			height: 4px;
-		}
+	&:after {
+		content: '';
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		width: 100%;
+		height: 4px;
+	}
 
-		&:hover:after {
-			background-color: oBrandGet('link-hover-text');
-		}
+	&:hover:after {
+		background-color: _oHeaderGet('link-hover-text');
+	}
 
-		&--highlight:after,
-		&[aria-selected="true"]:after, // deprecated
-		&[aria-current]:after {
-			background-color: oBrandGet('link-highlight-text');
-		}
-		};
+	&--highlight:after,
+	&[aria-selected="true"]:after, // deprecated
+	&[aria-current]:after {
+		background-color: _oHeaderGet('link-highlight-text');
+	}
 }
 
 /// Horizontal list item separator
@@ -97,7 +93,7 @@
 		top: 15%;
 		left: 0;
 		height: percentage($_o-header-item-separator-percentage-height);
-		border-left: $border-width solid oBrandGet('header-border', 'o-header');
+		border-left: $border-width solid _oHeaderGet('header-border');
 	}
 }
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -5,7 +5,6 @@
 
 /// Includes the correct mixin based on the row passed
 @mixin _oHeaderGetFeatureMixin($feature) {
-
 	@if $feature == 'anon' {
 		@include oHeaderAnon;
 	} @else if $feature == 'subnav' {

--- a/src/scss/features/_drawer.scss
+++ b/src/scss/features/_drawer.scss
@@ -94,7 +94,7 @@
 
 		.o-header__drawer-tools-logo {
 			@include oIconsBaseStyles;
-			@include oHeaderBrandImage('brand-ft-masthead', oColorsGetPaletteColor('black-80'), 210);
+			@include oHeaderBrandImage('brand-ft-masthead', oBrandGet('header-icon'), 210);
 			width: 210px;
 			height: 18px;
 			border-bottom: 0;

--- a/src/scss/features/_drawer.scss
+++ b/src/scss/features/_drawer.scss
@@ -1,368 +1,366 @@
 @mixin oHeaderDrawer() {
-	@include oBrandConfigureFor('o-header') {
-		// added to the document element, see n-ui/layout
-		.o-header__drawer {
-			background-color: oBrandGet('drawer-background');
-			font-family: $o-typography-sans;
+	// added to the document element, see n-ui/layout
+	.o-header__drawer {
+		background-color: _oHeaderGet('drawer-background');
+		font-family: $o-typography-sans;
 
-			&[data-o-header-drawer--js] {
-				position: fixed;
-				top: 0;
-				bottom: 0;
-				left: 0;
-				z-index: $_o-header-drawer-z-index;
-				width: 100%;
-				border-right: 1px solid oBrandGet('drawer-border');
+		&[data-o-header-drawer--js] {
+			position: fixed;
+			top: 0;
+			bottom: 0;
+			left: 0;
+			z-index: $_o-header-drawer-z-index;
+			width: 100%;
+			border-right: 1px solid _oHeaderGet('drawer-border');
+			// use a 2D transform because 3D are unsupported by IE9
+			// sass-lint:disable no-duplicate-properties
+			transform: translateX(-100%);
+			transform: translate3d(-100%, 0, 0);
+			// sass-lint:enable no-duplicate-properties
+
+			// this is literally the spec example for will-change
+			will-change: transform;
+
+			@include oGridRespondTo('M') {
+				width: $_o-header-drawer-width;
+			}
+
+			&[aria-hidden] {
+				@include oVisualEffectsShadowsElevation('low');
+
+				// because the transition is slightly bouncy it will reveal some of the background
+				border-left: 30px solid transparent;
+				margin-left: -30px;
+			}
+
+			&[aria-hidden="false"] {
 				// use a 2D transform because 3D are unsupported by IE9
 				// sass-lint:disable no-duplicate-properties
-				transform: translateX(-100%);
-				transform: translate3d(-100%, 0, 0);
+				transform: translateX(0);
+				transform: translate3d(0, 0, 0);
 				// sass-lint:enable no-duplicate-properties
-
-				// this is literally the spec example for will-change
-				will-change: transform;
-
-				@include oGridRespondTo('M') {
-					width: $_o-header-drawer-width;
-				}
-
-				&[aria-hidden] {
-					@include oVisualEffectsShadowsElevation('low');
-
-					// because the transition is slightly bouncy it will reveal some of the background
-					border-left: 30px solid transparent;
-					margin-left: -30px;
-				}
-
-				&[aria-hidden="false"] {
-					// use a 2D transform because 3D are unsupported by IE9
-					// sass-lint:disable no-duplicate-properties
-					transform: translateX(0);
-					transform: translate3d(0, 0, 0);
-					// sass-lint:enable no-duplicate-properties
-				}
 			}
 		}
+	}
 
-		// Supports different transitions for opening and closing
-		.o-header__drawer--opening,
-		.o-header__drawer--closing {
-			transition: transform 0.5s cubic-bezier(1, 0, 0.5, 1.2);
-		}
+	// Supports different transitions for opening and closing
+	.o-header__drawer--opening,
+	.o-header__drawer--closing {
+		transition: transform 0.5s cubic-bezier(1, 0, 0.5, 1.2);
+	}
 
-		.o-header__drawer-inner {
-			[data-o-header-drawer--js] & {
-				height: 100%;
-				overflow-y: auto;
-				// intertial scrolling for iOS Safari
-				// sass-lint:disable no-vendor-prefixes
-				-webkit-overflow-scrolling: touch;
-				// sass-lint:enable no-vendor-prefixes
-				// working draft
-				scroll-behavior: smooth;
-				// Windows 8+
-				// sass-lint:disable no-vendor-prefixes
-				-ms-overflow-style: -ms-autohiding-scrollbar;
-				// sass-lint:enable no-vendor-prefixes
-
-				// (╯°□°）╯︵ ┻━┻
-				// sass-lint:disable no-vendor-prefixes
-				&::-webkit-scrollbar {
-					// sass-lint:enable no-vendor-prefixes
-					width: 12px;
-				}
-				// sass-lint:disable no-vendor-prefixes
-				&::-webkit-scrollbar-thumb {
-					// sass-lint:enable no-vendor-prefixes
-					background: oColorsGetPaletteColor('black-30');
-					// you can't set the dimensions so use a border as a margin...
-					background-clip: content-box;
-					border: 4px solid transparent;
-				}
-			}
-		}
-
-		//
-		// Tools
-		//
-		.o-header__drawer-tools {
-			overflow: hidden;
-			padding: ($_o-header-drawer-padding-y * 1.5) 0 $_o-header-drawer-padding-y $_o-header-drawer-padding-x;
-			background-color: oBrandGet('drawer-tools-background');
-			color: oBrandGet('drawer-tools-text');
-		}
-
-		.o-header__drawer-tools-logo {
-			@include oIconsBaseStyles;
-			@include oHeaderBrandImage('brand-ft-masthead', oBrandGet('header-icon'), 210);
-			width: 210px;
-			height: 18px;
-			border-bottom: 0;
-		}
-
-		.o-header__drawer-tools-close {
-			// dividing by 1px removes the unit
-			@include oIconsGetIcon('cross', oBrandGet('drawer-tools-close'), $_o-header-icon-size-large, $iconset-version: 1);
-			float: right;
-			border: 0;
-			opacity: 0.75;
-			cursor: pointer;
-			margin-top: -10px;
-			&:hover,
-			&:focus {
-				opacity: 1;
-			}
-
-			[data-o-header-drawer--no-js] & {
-				display: none;
-			}
-		}
-
-		//
-		// Editions
-		//
-		.o-header__drawer-editions {
-			padding: 0 $_o-header-drawer-padding-x;
-		}
-
-		.o-header__drawer-editions-link {
-			color: oBrandGet('drawer-editions-link');
-			display: inline-block;
-			padding: $_o-header-drawer-padding-y/2 0 8px;
-			margin-left: 0.5em;
-			border-bottom: 0;
-			font-size: 18px;
-			text-decoration: underline;
-
-			&:first-child {
-				margin-left: 0;
-			}
-
-			&[aria-selected="true"], // deprecated
-			&[aria-current] {
-				color: oBrandGet('drawer-editions-link-highlight');
-				font-weight: 600;
-				text-decoration: none;
-				pointer-events: none;
-			}
-		}
-
-		//
-		// Search
-		//
-		.o-header__drawer-search {
-			padding: $_o-header-drawer-padding-y $_o-header-drawer-padding-x;
-
-			@include oGridRespondTo('L') {
-				display: none;
-			}
-		}
-
-		.o-header__drawer-search-form {
-			display: flex;
-		}
-
-		.o-header__drawer-search-term,
-		.o-header__drawer-search-submit {
-			box-sizing: border-box;
-			// ಥ_ಥ
-			height: 32px;
-			padding: 8px ($_o-header-drawer-padding-x / 2);
-			border: 1px solid;
-			// prevent zoom on focus
-			font-size: 100%;
-		}
-
-		.o-header__drawer-search-term {
-			background-color: oBrandGet('drawer-search-term-background');
-			border-color: oBrandGet('drawer-search-term-border');
-			flex-grow: 1;
-
-			&:focus { //currently overriden by o-normalise
-				border-color: oBrandGet('drawer-search-term-highlight-border');
-			}
-		}
-
-		.o-header__drawer-search-submit {
-			background-color: oBrandGet('drawer-search-submit-background');
-			border-color: oBrandGet('drawer-search-submit-border');
-
-			&:after {
-				@include oIconsGetIcon('search', oColorsGetPaletteColor('white'), $_o-header-icon-size, $iconset-version: 1);
-				content: '';
-				margin-top: -($_o-header-drawer-padding-y / 2);
-			}
-		}
-
-		//
-		// Lists
-		//
-		.o-header__drawer-menu {
-			color: oBrandGet('drawer-menu-text');
-			border-color: oBrandGet('drawer-menu-border');
-		}
-
-		.o-header__drawer-menu--user {
-			background-color: oBrandGet('drawer-menu-user-background');
-			padding-bottom: $_o-header-drawer-padding-y;
-			border-top: 1px solid oBrandGet('drawer-menu-user-border');
-		}
-
-		.o-header__drawer-menu-list {
-			list-style-type: none;
-			padding: 0;
-			margin: 0;
-			overflow: hidden;
-		}
-
-		.o-header__drawer-menu-list--child {
-			[data-o-header-drawer--no-js] & {
-				display: none;
-			}
-
-			[data-o-header-drawer--js] & {
-				// hide from the off to avoid any transition on page load
-				max-height: 0;
-				// take the contents away from tab order
-				visibility: hidden;
-				transition: max-height 0.25s ease-out;
-
-				&[aria-hidden="false"] {
-					background-color: oBrandGet('drawer-menu-list-background');
-					// magic number... you can't transition between 0 and unknown
-					// but as long as this is larger than the content it will do
-					max-height: 600px;
-					visibility: visible;
-					// a border would create some flickery layout
-					box-shadow: inset 0 -1px 0 oBrandGet('drawer-menu-border'), inset 0 1px 0 oBrandGet('drawer-menu-border');
-				}
-			}
-		}
-
-		.o-header__drawer-menu-item {
-			margin-top: 1px;
-		}
-
-		.o-header__drawer-menu-item--divide {
-			border-top: 2px solid oBrandGet('drawer-menu-border');
-		}
-
-		.o-header__drawer-menu-item--heading {
-			background-color: oBrandGet('drawer-menu-item-background');
-			padding: ($_o-header-drawer-padding-x / 2) $_o-header-drawer-padding-x;
-			font-weight: 600;
-		}
-
-		//
-		// Toggles
-		//
-		.o-header__drawer-menu-toggle-wrapper {
-			position: relative;
-		}
-
-		.o-header__drawer-menu-toggle {
-			position: absolute;
-			top: 0;
-			right: 0;
+	.o-header__drawer-inner {
+		[data-o-header-drawer--js] & {
 			height: 100%;
-			width: 42px;
-			// normalize the button
-			padding: 0;
-			text-align: left;
-			border: 0;
-			cursor: pointer;
-			// visually hide text...
-			font-size: 0;
+			overflow-y: auto;
+			// intertial scrolling for iOS Safari
+			// sass-lint:disable no-vendor-prefixes
+			-webkit-overflow-scrolling: touch;
+			// sass-lint:enable no-vendor-prefixes
+			// working draft
+			scroll-behavior: smooth;
+			// Windows 8+
+			// sass-lint:disable no-vendor-prefixes
+			-ms-overflow-style: -ms-autohiding-scrollbar;
+			// sass-lint:enable no-vendor-prefixes
 
-			&:before {
-				content: ' ';
-				margin-left: 9px; // magic number to vertically align icon in box
+			// (╯°□°）╯︵ ┻━┻
+			// sass-lint:disable no-vendor-prefixes
+			&::-webkit-scrollbar {
+				// sass-lint:enable no-vendor-prefixes
+				width: 12px;
 			}
-
-			&[aria-expanded="true"] {
-				&:before {
-					// don't download another icon...
-					transform: rotate(180deg);
-				}
-			}
-
-			&:hover {
-				// hide focus outline on hover
-				outline: 0;
-			}
-
-			[data-o-header-drawer--no-js] & {
-				display: none;
+			// sass-lint:disable no-vendor-prefixes
+			&::-webkit-scrollbar-thumb {
+				// sass-lint:enable no-vendor-prefixes
+				background: oColorsGetPaletteColor('black-30');
+				// you can't set the dimensions so use a border as a margin...
+				background-clip: content-box;
+				border: 4px solid transparent;
 			}
 		}
+	}
 
-		.o-header__drawer-menu-toggle--selected {
-			background: rgba(oBrandGet('drawer-selected-toggle-background'), 0.25);
+	//
+	// Tools
+	//
+	.o-header__drawer-tools {
+		overflow: hidden;
+		padding: ($_o-header-drawer-padding-y * 1.5) 0 $_o-header-drawer-padding-y $_o-header-drawer-padding-x;
+		background-color: _oHeaderGet('drawer-tools-background');
+		color: _oHeaderGet('drawer-tools-text');
+	}
 
-			&:before {
-				@include oIconsGetIcon('arrow-down', oBrandGet('drawer-selected-toggle-text'), $_o-header-icon-size, $iconset-version: 1);
-			}
+	.o-header__drawer-tools-logo {
+		@include oIconsBaseStyles;
+		@include oHeaderBrandImage('brand-ft-masthead', _oHeaderGet('header-icon'), 210);
+		width: 210px;
+		height: 18px;
+		border-bottom: 0;
+	}
+
+	.o-header__drawer-tools-close {
+		// dividing by 1px removes the unit
+		@include oIconsGetIcon('cross', _oHeaderGet('drawer-tools-close'), $_o-header-icon-size-large, $iconset-version: 1);
+		float: right;
+		border: 0;
+		opacity: 0.75;
+		cursor: pointer;
+		margin-top: -10px;
+		&:hover,
+		&:focus {
+			opacity: 1;
 		}
 
-		.o-header__drawer-menu-toggle--unselected {
-			background: rgba(oBrandGet('drawer-unselected-toggle-background'), 0.85);
+		[data-o-header-drawer--no-js] & {
+			display: none;
+		}
+	}
 
-			&:before {
-				@include oIconsGetIcon('arrow-down', oBrandGet('drawer-unselected-toggle-text'), $_o-header-icon-size, $iconset-version: 1);
-			}
+	//
+	// Editions
+	//
+	.o-header__drawer-editions {
+		padding: 0 $_o-header-drawer-padding-x;
+	}
+
+	.o-header__drawer-editions-link {
+		color: _oHeaderGet('drawer-editions-link');
+		display: inline-block;
+		padding: $_o-header-drawer-padding-y/2 0 8px;
+		margin-left: 0.5em;
+		border-bottom: 0;
+		font-size: 18px;
+		text-decoration: underline;
+
+		&:first-child {
+			margin-left: 0;
 		}
 
-		//
-		// Links
-		//
-		.o-header__drawer-menu-link {
-			color: oBrandGet('drawer-menu-link-text');
-			display: block;
-			padding: $_o-header-drawer-padding-y $_o-header-drawer-padding-x;
-			border-bottom: 0;
-			font-size: 18px;
-			text-decoration: none;
-
-			&:hover {
-				color: oBrandGet('drawer-menu-link-hover-text');
-			}
-
-			[aria-expanded="true"] + & {
-				background-color: oBrandGet('drawer-menu-link-background');
-			}
-		}
-
-		.o-header__drawer-menu-link--selected {
-			color: oBrandGet('drawer-menu-selected-link-text');
-			background-color: oBrandGet('drawer-menu-selected-link-background');
-
-			&:hover,
-			&:focus {
-				color: oBrandGet('drawer-menu-selected-link-hover-text');
-				//also overriden by o-normalise
-				outline-color: oBrandGet('drawer-menu-text');
-			}
-
-			[aria-expanded="true"] + & {
-				// specificity
-				background-color: oBrandGet('drawer-menu-selected-link-background');
-			}
-		}
-
-		.o-header__drawer-menu-link--parent {}
-
-		.o-header__drawer-menu-link--child {
-			padding-left: 40px;
-		}
-
-		.o-header__drawer-menu-link--secondary {
+		&[aria-selected="true"], // deprecated
+		&[aria-current] {
+			color: _oHeaderGet('drawer-editions-link-highlight');
 			font-weight: 600;
+			text-decoration: none;
+			pointer-events: none;
+		}
+	}
+
+	//
+	// Search
+	//
+	.o-header__drawer-search {
+		padding: $_o-header-drawer-padding-y $_o-header-drawer-padding-x;
+
+		@include oGridRespondTo('L') {
+			display: none;
+		}
+	}
+
+	.o-header__drawer-search-form {
+		display: flex;
+	}
+
+	.o-header__drawer-search-term,
+	.o-header__drawer-search-submit {
+		box-sizing: border-box;
+		// ಥ_ಥ
+		height: 32px;
+		padding: 8px ($_o-header-drawer-padding-x / 2);
+		border: 1px solid;
+		// prevent zoom on focus
+		font-size: 100%;
+	}
+
+	.o-header__drawer-search-term {
+		background-color: _oHeaderGet('drawer-search-term-background');
+		border-color: _oHeaderGet('drawer-search-term-border');
+		flex-grow: 1;
+
+		&:focus { //currently overriden by o-normalise
+			border-color: _oHeaderGet('drawer-search-term-highlight-border');
+		}
+	}
+
+	.o-header__drawer-search-submit {
+		background-color: _oHeaderGet('drawer-search-submit-background');
+		border-color: _oHeaderGet('drawer-search-submit-border');
+
+		&:after {
+			@include oIconsGetIcon('search', oColorsGetPaletteColor('white'), $_o-header-icon-size, $iconset-version: 1);
+			content: '';
+			margin-top: -($_o-header-drawer-padding-y / 2);
+		}
+	}
+
+	//
+	// Lists
+	//
+	.o-header__drawer-menu {
+		color: _oHeaderGet('drawer-menu-text');
+		border-color: _oHeaderGet('drawer-menu-border');
+	}
+
+	.o-header__drawer-menu--user {
+		background-color: _oHeaderGet('drawer-menu-user-background');
+		padding-bottom: $_o-header-drawer-padding-y;
+		border-top: 1px solid _oHeaderGet('drawer-menu-user-border');
+	}
+
+	.o-header__drawer-menu-list {
+		list-style-type: none;
+		padding: 0;
+		margin: 0;
+		overflow: hidden;
+	}
+
+	.o-header__drawer-menu-list--child {
+		[data-o-header-drawer--no-js] & {
+			display: none;
 		}
 
-		.o-header__drawer-menu-link-detail {
-			display: block;
-			margin-top: 0.25em;
-			font-size: 14px;
+		[data-o-header-drawer--js] & {
+			// hide from the off to avoid any transition on page load
+			max-height: 0;
+			// take the contents away from tab order
+			visibility: hidden;
+			transition: max-height 0.25s ease-out;
+
+			&[aria-hidden="false"] {
+				background-color: _oHeaderGet('drawer-menu-list-background');
+				// magic number... you can't transition between 0 and unknown
+				// but as long as this is larger than the content it will do
+				max-height: 600px;
+				visibility: visible;
+				// a border would create some flickery layout
+				box-shadow: inset 0 -1px 0 _oHeaderGet('drawer-menu-border'), inset 0 1px 0 _oHeaderGet('drawer-menu-border');
+			}
 		}
+	}
+
+	.o-header__drawer-menu-item {
+		margin-top: 1px;
+	}
+
+	.o-header__drawer-menu-item--divide {
+		border-top: 2px solid _oHeaderGet('drawer-menu-border');
+	}
+
+	.o-header__drawer-menu-item--heading {
+		background-color: _oHeaderGet('drawer-menu-item-background');
+		padding: ($_o-header-drawer-padding-x / 2) $_o-header-drawer-padding-x;
+		font-weight: 600;
+	}
+
+	//
+	// Toggles
+	//
+	.o-header__drawer-menu-toggle-wrapper {
+		position: relative;
+	}
+
+	.o-header__drawer-menu-toggle {
+		position: absolute;
+		top: 0;
+		right: 0;
+		height: 100%;
+		width: 42px;
+		// normalize the button
+		padding: 0;
+		text-align: left;
+		border: 0;
+		cursor: pointer;
+		// visually hide text...
+		font-size: 0;
+
+		&:before {
+			content: ' ';
+			margin-left: 9px; // magic number to vertically align icon in box
+		}
+
+		&[aria-expanded="true"] {
+			&:before {
+				// don't download another icon...
+				transform: rotate(180deg);
+			}
+		}
+
+		&:hover {
+			// hide focus outline on hover
+			outline: 0;
+		}
+
+		[data-o-header-drawer--no-js] & {
+			display: none;
+		}
+	}
+
+	.o-header__drawer-menu-toggle--selected {
+		background: rgba(_oHeaderGet('drawer-selected-toggle-background'), 0.25);
+
+		&:before {
+			@include oIconsGetIcon('arrow-down', _oHeaderGet('drawer-selected-toggle-text'), $_o-header-icon-size, $iconset-version: 1);
+		}
+	}
+
+	.o-header__drawer-menu-toggle--unselected {
+		background: rgba(_oHeaderGet('drawer-unselected-toggle-background'), 0.85);
+
+		&:before {
+			@include oIconsGetIcon('arrow-down', _oHeaderGet('drawer-unselected-toggle-text'), $_o-header-icon-size, $iconset-version: 1);
+		}
+	}
+
+	//
+	// Links
+	//
+	.o-header__drawer-menu-link {
+		color: _oHeaderGet('drawer-menu-link-text');
+		display: block;
+		padding: $_o-header-drawer-padding-y $_o-header-drawer-padding-x;
+		border-bottom: 0;
+		font-size: 18px;
+		text-decoration: none;
+
+		&:hover {
+			color: _oHeaderGet('drawer-menu-link-hover-text');
+		}
+
+		[aria-expanded="true"] + & {
+			background-color: _oHeaderGet('drawer-menu-link-background');
+		}
+	}
+
+	.o-header__drawer-menu-link--selected {
+		color: _oHeaderGet('drawer-menu-selected-link-text');
+		background-color: _oHeaderGet('drawer-menu-selected-link-background');
+
+		&:hover,
+		&:focus {
+			color: _oHeaderGet('drawer-menu-selected-link-hover-text');
+			//also overriden by o-normalise
+			outline-color: _oHeaderGet('drawer-menu-text');
+		}
+
+		[aria-expanded="true"] + & {
+			// specificity
+			background-color: _oHeaderGet('drawer-menu-selected-link-background');
+		}
+	}
+
+	.o-header__drawer-menu-link--parent {}
+
+	.o-header__drawer-menu-link--child {
+		padding-left: 40px;
+	}
+
+	.o-header__drawer-menu-link--secondary {
+		font-weight: 600;
+	}
+
+	.o-header__drawer-menu-link-detail {
+		display: block;
+		margin-top: 0.25em;
+		font-size: 14px;
 	}
 }

--- a/src/scss/features/_megamenu.scss
+++ b/src/scss/features/_megamenu.scss
@@ -8,53 +8,51 @@
 		}
 	}
 
-	@include oBrandConfigureFor('o-header') {
-		.o-header__mega {
-			@include oTypographySans(0);
-			@include oTypographyProgressiveFontFallback('sans', 0);
-			@include oVisualEffectsShadowsElevation('low');
-			display: none;
-			position: absolute;
-			top: 100%;
-			left: oGridGutter('L');
-			right: oGridGutter('L');
-			z-index: $_o-header-mega-z-index;
-			box-sizing: border-box;
-			padding: $_o-header-mega-padding-y 0;
-			border-top: 1px solid oBrandGet('header-border');
-			background-color: oBrandGet('mega-menu-background');
+	.o-header__mega {
+		@include oTypographySans(0);
+		@include oTypographyProgressiveFontFallback('sans', 0);
+		@include oVisualEffectsShadowsElevation('low');
+		display: none;
+		position: absolute;
+		top: 100%;
+		left: oGridGutter('L');
+		right: oGridGutter('L');
+		z-index: $_o-header-mega-z-index;
+		box-sizing: border-box;
+		padding: $_o-header-mega-padding-y 0;
+		border-top: 1px solid _oHeaderGet('header-border');
+		background-color: _oHeaderGet('mega-menu-background');
 
-			&[aria-expanded="true"],
-			// core experience fallback
-			[data-o-header--no-js] :hover > & {
-				display: block;
-			}
+		&[aria-expanded="true"],
+		// core experience fallback
+		[data-o-header--no-js] :hover > & {
+			display: block;
 		}
+	}
 
-		.o-header__mega--animation {
-			animation: o-header-mega 0.5s ease-out;
+	.o-header__mega--animation {
+		animation: o-header-mega 0.5s ease-out;
+	}
+
+	.o-header__mega-wrapper {
+		display: table;
+		table-layout: fixed;
+		width: 100%;
+		// no margins for table cells... also so we avoid using :last-child for old IE
+		border-spacing: $_o-header-mega-padding-x 0;
+		margin-left: $_o-header-mega-padding-x * -1;
+	}
+
+	.o-header__mega-column {
+		display: table-cell;
+		padding-left: $_o-header-mega-padding-x;
+		border-left: 1px solid _oHeaderGet('header-border');
+
+		&:first-child {
+			border-left: 0;
+			padding-left: 0;
 		}
-
-		.o-header__mega-wrapper {
-			display: table;
-			table-layout: fixed;
-			width: 100%;
-			// no margins for table cells... also so we avoid using :last-child for old IE
-			border-spacing: $_o-header-mega-padding-x 0;
-			margin-left: $_o-header-mega-padding-x * -1;
-		}
-
-		.o-header__mega-column {
-			display: table-cell;
-			padding-left: $_o-header-mega-padding-x;
-			border-left: 1px solid oBrandGet('header-border');
-
-			&:first-child {
-				border-left: 0;
-				padding-left: 0;
-			}
-		}
-	};
+	}
 
 	.o-header__mega-column--articles {
 

--- a/src/scss/features/_search.scss
+++ b/src/scss/features/_search.scss
@@ -1,57 +1,55 @@
 @mixin oHeaderSearch() {
-	@include oBrandConfigureFor('o-header') {
-		.o-header__search {
-			padding: $_o-header-padding-y 0;
-			text-align: center;
-			background: oBrandGet('search-background');
+	.o-header__search {
+		padding: $_o-header-padding-y 0;
+		text-align: center;
+		background: _oHeaderGet('search-background');
 
-			&[aria-hidden="false"] {
-				display: block;
-			}
+		&[aria-hidden="false"] {
+			display: block;
 		}
+	}
 
-		[data-o-header-search] {
-			display: none;
+	[data-o-header-search] {
+		display: none;
+	}
+
+	.o-header__search-form {
+		display: flex;
+		align-items: center;
+		max-width: 640px;
+		margin: 0 auto;
+	}
+
+	.o-header__search-term,
+	.o-header__search-submit {
+		// This is mostly for <= IE9, flexbox should deal with everything else
+		line-height: normal;
+		box-sizing: border-box;
+		height: 32px;
+		vertical-align: middle;
+	}
+
+	.o-header__search-term {
+		@include oTypographySans();
+		// match o-buttons
+		@include oButtonsSize('default');
+		border-radius: $_o-buttons-border-radius;
+		// normalize
+		background: white;
+		border-style: solid;
+		border-color: transparent;
+		// oh, webkit...
+		box-shadow: none;
+		// fill!
+		min-width: 50%;
+		flex-grow: 1;
+
+		&:focus {
+			//also, overriden by o-normalise
+			outline: none;
+			border-color: _oHeaderGet('search-border');
 		}
-
-		.o-header__search-form {
-			display: flex;
-			align-items: center;
-			max-width: 640px;
-			margin: 0 auto;
-		}
-
-		.o-header__search-term,
-		.o-header__search-submit {
-			// This is mostly for <= IE9, flexbox should deal with everything else
-			line-height: normal;
-			box-sizing: border-box;
-			height: 32px;
-			vertical-align: middle;
-		}
-
-		.o-header__search-term {
-			@include oTypographySans();
-			// match o-buttons
-			@include oButtonsSize('default');
-			border-radius: $_o-buttons-border-radius;
-			// normalize
-			background: white;
-			border-style: solid;
-			border-color: transparent;
-			// oh, webkit...
-			box-shadow: none;
-			// fill!
-			min-width: 50%;
-			flex-grow: 1;
-
-			&:focus {
-				//also, overriden by o-normalise
-				outline: none;
-				border-color: oBrandGet('search-border');
-			}
-		}
-	};
+	}
 
 	.o-header__search-submit {
 		@include oButtons($theme: $_o-header-buttons-theme);

--- a/src/scss/features/_subnav.scss
+++ b/src/scss/features/_subnav.scss
@@ -1,147 +1,145 @@
 @mixin oHeaderSubnav() {
-	@include oBrandConfigureFor('o-header') {
-		.o-header__subnav {
-			@include oTypographySans(0);
-			background-color: oBrandGet('subnav-background');
-			border-bottom: 1px solid oBrandGet('subnav-border');
+	.o-header__subnav {
+		@include oTypographySans(0);
+		background-color: _oHeaderGet('subnav-background');
+		border-bottom: 1px solid _oHeaderGet('subnav-border');
+	}
+
+	.o-header__subnav-wrap-outside {
+		margin-left: -$_o-header-sub-header-focus-margin;
+
+		[data-o-header--js] & {
+			overflow: hidden;
+			// height *needs* setting so we can hide scrollbars.
+			// This is the content height of .o-header__subnav-content
+			height: $_o-header-subhav-height;
 		}
+	}
 
-		.o-header__subnav-wrap-outside {
-			margin-left: -$_o-header-sub-header-focus-margin;
+	.o-header__subnav-wrap-inside {
+		overflow: auto;
 
-			[data-o-header--js] & {
-				overflow: hidden;
-				// height *needs* setting so we can hide scrollbars.
-				// This is the content height of .o-header__subnav-content
-				height: $_o-header-subhav-height;
-			}
+		[data-o-header--js] & {
+			// inertial scrolling for iOS Safari
+			// sass-lint:disable no-vendor-prefixes
+			-webkit-overflow-scrolling: touch;
+			// sass-lint:enable no-vendor-prefixes
+			// working draft
+			scroll-behavior: smooth;
+			// hide the scrollbar beneath the waves/many wrappers. 30px should be plenty.
+			padding-bottom: 30px;
 		}
+	}
 
-		.o-header__subnav-wrap-inside {
-			overflow: auto;
+	.o-header__subnav-content {
+		white-space: nowrap;
+		margin-left: $_o-header-sub-header-focus-margin;
+	}
 
-			[data-o-header--js] & {
-				// inertial scrolling for iOS Safari
-				// sass-lint:disable no-vendor-prefixes
-				-webkit-overflow-scrolling: touch;
-				// sass-lint:enable no-vendor-prefixes
-				// working draft
-				scroll-behavior: smooth;
-				// hide the scrollbar beneath the waves/many wrappers. 30px should be plenty.
-				padding-bottom: 30px;
-			}
-		}
+	.o-header__subnav-list {
+		display: inline-block;
+		padding: 0;
+		margin: 0;
 
-		.o-header__subnav-content {
-			white-space: nowrap;
-			margin-left: $_o-header-sub-header-focus-margin;
-		}
-
-		.o-header__subnav-list {
-			display: inline-block;
-			padding: 0;
-			margin: 0;
-
-			// Separators for subnav lists are positioned relative to the subnavs first item
-			// to avoid positioning subnavs relative. This is so absolute childen of the subnav are
-			// positioned relative to their closest positioned ancestor `o-header__container`.
-			// An example benefit is o-tooltip support against sub nav items.
-			& + & .o-header__subnav-item {
-				&:first-child {
-					@include _oHeaderItemSeparatorContent();
-					&:before {
-						top: 50%;
-						margin-top: - $_o-header-subhav-height * $_o-header-item-separator-percentage-height / 2;
-						height: $_o-header-subhav-height * $_o-header-item-separator-percentage-height;
-					}
-				}
-			}
-		}
-
-		.o-header__subnav-item {
-			position: relative;
-			display: inline-block;
-			padding-left: 6px;
-
-			.o-header__subnav-list--children & {
-				padding-left: 16px;
-			}
-
+		// Separators for subnav lists are positioned relative to the subnavs first item
+		// to avoid positioning subnavs relative. This is so absolute childen of the subnav are
+		// positioned relative to their closest positioned ancestor `o-header__container`.
+		// An example benefit is o-tooltip support against sub nav items.
+		& + & .o-header__subnav-item {
 			&:first-child {
-				// align left side correctly
-				padding-left: 0;
-			}
-
-			.o-header__subnav-list--breadcrumb & {
+				@include _oHeaderItemSeparatorContent();
 				&:before {
-					@include oIconsGetIcon('arrow-right', oBrandGet('link-highlight-text'), $_o-header-icon-size-small, $iconset-version: 1);
-					content: '';
-					position: relative;
-					top: 0.125em;
-					margin-right: 6px;
-				}
-
-				&:first-child:before {
-					content: none;
+					top: 50%;
+					margin-top: - $_o-header-subhav-height * $_o-header-item-separator-percentage-height / 2;
+					height: $_o-header-subhav-height * $_o-header-item-separator-percentage-height;
 				}
 			}
 		}
+	}
 
-		.o-header__subnav-link {
-			@include oHeaderLink;
-			@include oHeaderFancyLink;
-			color: oBrandGet('subnav-link');
-			display: inline-block;
-			padding: 8px 0;
+	.o-header__subnav-item {
+		position: relative;
+		display: inline-block;
+		padding-left: 6px;
 
-			.o-header__subnav-list--breadcrumb & {
-				color: oBrandGet('link-highlight-text');
-				text-transform: uppercase;
-				font-weight: 600;
-			}
+		.o-header__subnav-list--children & {
+			padding-left: 16px;
 		}
 
-		.o-header__subnav-link--right {
-			float: right;
+		&:first-child {
+			// align left side correctly
+			padding-left: 0;
+		}
+
+		.o-header__subnav-list--breadcrumb & {
+			&:before {
+				@include oIconsGetIcon('arrow-right', _oHeaderGet('link-highlight-text'), $_o-header-icon-size-small, $iconset-version: 1);
+				content: '';
+				position: relative;
+				top: 0.125em;
+				margin-right: 6px;
+			}
+
+			&:first-child:before {
+				content: none;
+			}
+		}
+	}
+
+	.o-header__subnav-link {
+		@include oHeaderLink;
+		@include oHeaderFancyLink;
+		color: _oHeaderGet('subnav-link');
+		display: inline-block;
+		padding: 8px 0;
+
+		.o-header__subnav-list--breadcrumb & {
+			color: _oHeaderGet('link-highlight-text');
+			text-transform: uppercase;
+			font-weight: 600;
+		}
+	}
+
+	.o-header__subnav-link--right {
+		float: right;
+		display: none;
+		@include oGridRespondTo('M') {
+			display: block;
+		}
+	}
+
+	.o-header__subnav-button {
+		@include oIconsGetIcon('arrow-left', _oHeaderGet('subnav-button-text'), $_o-header-icon-size, $apply-width-height: false, $iconset-version: 1);
+		background-color: _oHeaderGet('subnav-button-background');
+		position: absolute;
+		top: 0;
+		width: #{$_o-header-icon-size}px;
+		height: 100%;
+		padding: 0;
+		border: 0;
+		transition: 0.25s opacity 0.5s;
+
+		&:hover {
+			background-color: _oHeaderGet('subnav-button-hover-background');
+		}
+
+		&[disabled] {
+			opacity: 0;
+			pointer-events: none;
+		}
+
+		[data-o-header--no-js] & {
 			display: none;
-			@include oGridRespondTo('M') {
-				display: block;
-			}
 		}
+	}
 
-		.o-header__subnav-button {
-			@include oIconsGetIcon('arrow-left', oBrandGet('subnav-button-text'), $_o-header-icon-size, $apply-width-height: false, $iconset-version: 1);
-			background-color: oBrandGet('subnav-button-background');
-			position: absolute;
-			top: 0;
-			width: #{$_o-header-icon-size}px;
-			height: 100%;
-			padding: 0;
-			border: 0;
-			transition: 0.25s opacity 0.5s;
+	.o-header__subnav-button--left {
+		left: 0;
+	}
 
-			&:hover {
-				background-color: oBrandGet('subnav-button-hover-background');
-			}
-
-			&[disabled] {
-				opacity: 0;
-				pointer-events: none;
-			}
-
-			[data-o-header--no-js] & {
-				display: none;
-			}
-		}
-
-		.o-header__subnav-button--left {
-			left: 0;
-		}
-
-		.o-header__subnav-button--right {
-			right: 0;
-			// don't download another icon...
-			transform: rotate(180deg);
-		}
+	.o-header__subnav-button--right {
+		right: 0;
+		// don't download another icon...
+		transform: rotate(180deg);
 	}
 }

--- a/src/scss/features/_top.scss
+++ b/src/scss/features/_top.scss
@@ -78,80 +78,79 @@
 		}
 	}
 
-	@include oBrandConfigureFor('o-header') {
-		.o-header__top-link--menu {
-			&:before {
-				// container size (24) is only included for the fallback image.
-				// IE8 has a static stylesheet generated for the L breakpoint.
-				@include oIconsGetIcon('hamburger', oBrandGet('header-icon'), $_o-header-icon-size-large, $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
-			}
+	.o-header__top-link--menu {
+		&:before {
+			// container size (24) is only included for the fallback image.
+			// IE8 has a static stylesheet generated for the L breakpoint.
+			@include oIconsGetIcon('hamburger', _oHeaderGet('header-icon'), $_o-header-icon-size-large, $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
+		}
+	}
+
+	.o-header__top-link--search {
+		&:before {
+			@include oIconsGetIcon('search', _oHeaderGet('header-icon'), $_o-header-icon-size-large, $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
 		}
 
-		.o-header__top-link--search {
-			&:before {
-				@include oIconsGetIcon('search', oBrandGet('header-icon'), $_o-header-icon-size-large, $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
-			}
-
-			// when used in tandem with the menu toggle, hide this on smaller screen sizes
-			.o-header__top-link--menu + & {
-				@include oGridRespondTo($until: 'L') {
-					display: none;
-				}
-			}
-		}
-
-		.o-header__top-link--myft {
-			&:before {
-				@include oHeaderBrandImage('brand-myft', oBrandGet('header-icon'), 52);
-				// this is not a very square icon
-				width: 35px;
-				// Remove the negative margin added for new icons which have additional padding
-				margin-top: 0;
-
-				@include oGridRespondTo('M') {
-					width: 44px;
-				}
-
-				@include oGridRespondTo('L') {
-					width: 52px;
-				}
-			}
-		}
-
-		.o-header__top-link-label {
-			/* Deprecate this label in next breaking release (v7), but for v6.12.0
-			display-none it so that layout won't break and people don't have
-			to update their markup to get the change
-			*/
-			display: none;
-		}
-
-		.o-header__top-logo {
-			@include oHeaderBrandImage('brand-ft-masthead', oBrandGet('header-icon'), 500);
-			@include oHeaderLogoSize('XS');
-
-			display: block;
-			border: 0;
-			margin: 16px auto;
-			background-size: 100% 100%; // Edge SVG background clipped when scaled https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4705340/
-			background-position: 50%;
-			background-repeat: no-repeat;
-
-			@include oGridRespondTo('S') {
-				@include oHeaderLogoSize('S');
-			}
-
-			@include oGridRespondTo('M') {
-				@include oHeaderLogoSize('M');
-				margin-top: 24px;
-				margin-bottom: 24px;
-			}
-
-			@include oGridRespondTo('L') {
-				@include oHeaderLogoSize('L');
-				margin-top: 30px;
-				margin-bottom: 30px;
+		// when used in tandem with the menu toggle, hide this on smaller screen sizes
+		.o-header__top-link--menu + & {
+			@include oGridRespondTo($until: 'L') {
+				display: none;
 			}
 		}
 	}
+
+	.o-header__top-link--myft {
+		&:before {
+			@include oHeaderBrandImage('brand-myft', _oHeaderGet('header-icon'), 52);
+			// this is not a very square icon
+			width: 35px;
+			// Remove the negative margin added for new icons which have additional padding
+			margin-top: 0;
+
+			@include oGridRespondTo('M') {
+				width: 44px;
+			}
+
+			@include oGridRespondTo('L') {
+				width: 52px;
+			}
+		}
+	}
+
+	.o-header__top-link-label {
+		/* Deprecate this label in next breaking release (v7), but for v6.12.0
+		display-none it so that layout won't break and people don't have
+		to update their markup to get the change
+		*/
+		display: none;
+	}
+
+	.o-header__top-logo {
+		@include oHeaderBrandImage('brand-ft-masthead', _oHeaderGet('header-icon'), 500);
+		@include oHeaderLogoSize('XS');
+
+		display: block;
+		border: 0;
+		margin: 16px auto;
+		background-size: 100% 100%; // Edge SVG background clipped when scaled https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4705340/
+		background-position: 50%;
+		background-repeat: no-repeat;
+
+		@include oGridRespondTo('S') {
+			@include oHeaderLogoSize('S');
+		}
+
+		@include oGridRespondTo('M') {
+			@include oHeaderLogoSize('M');
+			margin-top: 24px;
+			margin-bottom: 24px;
+		}
+
+		@include oGridRespondTo('L') {
+			@include oHeaderLogoSize('L');
+			margin-top: 30px;
+			margin-bottom: 30px;
+		}
+	}
+
 }

--- a/src/scss/features/_transparent.scss
+++ b/src/scss/features/_transparent.scss
@@ -1,55 +1,52 @@
 @mixin oHeaderTransparent() {
-	@include oBrandConfigureFor('o-header', 'transparent') {
+	.o-header--transparent {
+		border-color: _oHeaderGet('header-border', $from: 'transparent');
+		background-color: _oHeaderGet('header-background', $from: 'transparent');
 
-		.o-header--transparent {
-			border-color: oBrandGet('header-border');
-			background-color: oBrandGet('header-background');
+		.o-header__row {
+			border-bottom-color: _oHeaderGet('header-border', $from: 'transparent');
+		}
 
-			.o-header__row {
-				border-bottom-color: oBrandGet('header-border');
+		.o-header__top-link--menu:before {
+			@include oIconsGetIcon('hamburger', _oHeaderGet('header-icon', $from: 'transparent'), $_o-header-icon-size-large, $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
+		}
+
+		.o-header__top-link--search:before {
+			@include oIconsGetIcon('search', _oHeaderGet('header-icon', $from: 'transparent'), $_o-header-icon-size-large, $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
+		}
+
+		.o-header__top-link--myft:before {
+			@include oHeaderBrandImage('brand-myft', _oHeaderGet('header-icon', $from: 'transparent'), 52);
+		}
+
+		.o-header__top-logo {
+			@include oHeaderBrandImage('brand-ft-masthead', _oHeaderGet('header-icon', $from: 'transparent'), 500);
+		}
+
+		.o-header__nav-button {
+			@include oButtons($theme: 'inverse');
+		}
+
+		.o-header__nav-link,
+		.o-header__anon-link {
+			&:hover {
+				color: _oHeaderGet('link-hover-text', $from: 'transparent');
 			}
 
-			.o-header__top-link--menu:before {
-				@include oIconsGetIcon('hamburger', oBrandGet('header-icon'), $_o-header-icon-size-large, $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
+			&:hover:after {
+				background-color: _oHeaderGet('link-hover-text', $from: 'transparent');
 			}
 
-			.o-header__top-link--search:before {
-				@include oIconsGetIcon('search', oBrandGet('header-icon'), $_o-header-icon-size-large, $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
+			&--highlight,
+			&[aria-selected="true"], // deprecated
+			&[aria-current] {
+				color: _oHeaderGet('link-highlight-text', $from: 'transparent');
 			}
 
-			.o-header__top-link--myft:before {
-				@include oHeaderBrandImage('brand-myft', oBrandGet('header-icon'), 52);
-			}
-
-			.o-header__top-logo {
-				@include oHeaderBrandImage('brand-ft-masthead', oBrandGet('header-icon'), 500);
-			}
-
-			.o-header__nav-button {
-				@include oButtons($theme: 'inverse');
-			}
-
-			.o-header__nav-link,
-			.o-header__anon-link {
-				&:hover {
-					color: oBrandGet('link-hover-text');
-				}
-
-				&:hover:after {
-					background-color: oBrandGet('link-hover-text');
-				}
-
-				&--highlight,
-				&[aria-selected="true"], // deprecated
-				&[aria-current] {
-					color: oBrandGet('link-highlight-text');
-				}
-
-				&--highlight:after,
-				&[aria-selected="true"]:after, // deprecated
-				&[aria-current]:after {
-					background-color: oBrandGet('link-highlight-text');
-				}
+			&--highlight:after,
+			&[aria-selected="true"]:after, // deprecated
+			&[aria-current]:after {
+				background-color: _oHeaderGet('link-highlight-text', $from: 'transparent');
 			}
 		}
 	}

--- a/src/scss/features/_transparent.scss
+++ b/src/scss/features/_transparent.scss
@@ -1,28 +1,28 @@
 @mixin oHeaderTransparent() {
-	@include oBrandConfigureFor('o-header') {
+	@include oBrandConfigureFor('o-header', 'transparent') {
 
 		.o-header--transparent {
-			border-color: rgba(oBrandGet('transparency'), 0.4);
-			background-color: transparent;
+			border-color: oBrandGet('header-border');
+			background-color: oBrandGet('header-background');
 
 			.o-header__row {
-				border-bottom-color: rgba(oBrandGet('transparency'), 0.4);
+				border-bottom-color: oBrandGet('header-border');
 			}
 
 			.o-header__top-link--menu:before {
-				@include oIconsGetIcon('hamburger', oBrandGet('transparency'), $_o-header-icon-size-large, $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
+				@include oIconsGetIcon('hamburger', oBrandGet('header-icon'), $_o-header-icon-size-large, $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
 			}
 
 			.o-header__top-link--search:before {
-				@include oIconsGetIcon('search', oBrandGet('transparency'), $_o-header-icon-size-large, $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
+				@include oIconsGetIcon('search', oBrandGet('header-icon'), $_o-header-icon-size-large, $apply-base-styles: false, $apply-width-height: false, $iconset-version: 1);
 			}
 
 			.o-header__top-link--myft:before {
-				@include oHeaderBrandImage('brand-myft', oBrandGet('transparency'), 52);
+				@include oHeaderBrandImage('brand-myft', oBrandGet('header-icon'), 52);
 			}
 
 			.o-header__top-logo {
-				@include oHeaderBrandImage('brand-ft-masthead', oBrandGet('transparency'), 500);
+				@include oHeaderBrandImage('brand-ft-masthead', oBrandGet('header-icon'), 500);
 			}
 
 			.o-header__nav-button {
@@ -32,23 +32,23 @@
 			.o-header__nav-link,
 			.o-header__anon-link {
 				&:hover {
-					color: oBrandGet('transparency');
+					color: oBrandGet('link-hover-text');
 				}
 
 				&:hover:after {
-					background-color: oBrandGet('transparency');
+					background-color: oBrandGet('link-hover-text');
 				}
 
 				&--highlight,
 				&[aria-selected="true"], // deprecated
 				&[aria-current] {
-					color: oBrandGet('transparency');
+					color: oBrandGet('link-highlight-text');
 				}
 
 				&--highlight:after,
 				&[aria-selected="true"]:after, // deprecated
 				&[aria-current]:after {
-					background-color: oBrandGet('transparency');
+					background-color: oBrandGet('link-highlight-text');
 				}
 			}
 		}


### PR DESCRIPTION
- Remove deprecated uses of `o-brand`.
- Move variables for the `transparent` variant.
- Only output features which are supported by the brand, as configured in `_brand.scss`, unless specifically requested.

Easier to review ignoring whitepace: https://github.com/Financial-Times/o-header/pull/308/files?w=1