### PR TITLE
remove arrow flash

### DIFF
--- a/demos/src/subnav.json
+++ b/demos/src/subnav.json
@@ -465,7 +465,8 @@
 		],
 		"children": [
 			{
-				"name": "US Economy",
+				"name": "US Economyaki",
+				"selected": true,
 				"href": "#"
 			},
 			{
@@ -474,7 +475,6 @@
 			},
 			{
 				"name": "US Companies",
-				"selected": true,
 				"href": "#"
 			}
 		]

--- a/demos/src/subnav.json
+++ b/demos/src/subnav.json
@@ -465,13 +465,13 @@
 		],
 		"children": [
 			{
-				"name": "US Economyaki",
-				"selected": true,
+				"name": "US Economy",
 				"href": "#"
 			},
 			{
 				"name": "US Politics & Policy",
-				"href": "#"
+				"href": "#",
+				"selected": true
 			},
 			{
 				"name": "US Companies",

--- a/demos/src/subnav.json
+++ b/demos/src/subnav.json
@@ -470,11 +470,11 @@
 			},
 			{
 				"name": "US Politics & Policy",
-				"href": "#",
-				"selected": true
+				"href": "#"
 			},
 			{
 				"name": "US Companies",
+				"selected": true,
 				"href": "#"
 			}
 		]

--- a/src/js/subnav.js
+++ b/src/js/subnav.js
@@ -43,7 +43,6 @@ function init(headerEl) {
 			if (direction(button) === 'left') {
 				button.disabled = wrapper.scrollLeft === 0;
 			} else {
-				button.disabled = true;
 				const remaining = scrollWidth - wrapperWidth - wrapper.scrollLeft;
 				// Allow a little difference as scrollWidth is fast, not accurate.
 				button.disabled = remaining <= 1;

--- a/src/js/subnav.js
+++ b/src/js/subnav.js
@@ -8,7 +8,7 @@ function init(headerEl) {
 	}
 
 	const buttons = Array.from(subnav.getElementsByTagName('button'));
-	const wrapper = window.w = subnav.querySelector('[data-o-header-subnav-wrapper]');
+	const wrapper = subnav.querySelector('[data-o-header-subnav-wrapper]');
 
 	let scrollWidth;
 	let wrapperWidth = wrapper.clientWidth;

--- a/src/js/subnav.js
+++ b/src/js/subnav.js
@@ -73,8 +73,7 @@ function init(headerEl) {
 		button.onclick = scroll;
 	});
 
-	//Let nav content and selection load before we decide how scrolling should behave
-	setTimeout(checkCurrentPosition, 500);
+	checkCurrentPosition();
 }
 
 export default { init };

--- a/src/js/subnav.js
+++ b/src/js/subnav.js
@@ -25,6 +25,7 @@ function init(headerEl) {
 			if (direction(button) === 'left') {
 				button.disabled = wrapper.scrollLeft === 0;
 			} else {
+				button.disabled = true;
 				const remaining = scrollWidth - clientWidth - wrapper.scrollLeft;
 				// Allow a little difference as scrollWidth is fast, not accurate.
 				button.disabled = remaining <= 1;
@@ -68,7 +69,6 @@ function init(headerEl) {
 		button.onclick = scroll;
 	});
 
-	scrollable();
 	scrollToCurrent();
 }
 

--- a/src/js/subnav.js
+++ b/src/js/subnav.js
@@ -8,7 +8,7 @@ function init(headerEl) {
 	}
 
 	const buttons = Array.from(subnav.getElementsByTagName('button'));
-	const wrapper = subnav.querySelector('[data-o-header-subnav-wrapper]');
+	const wrapper = window.w = subnav.querySelector('[data-o-header-subnav-wrapper]');
 
 	let scrollWidth;
 	let wrapperWidth = wrapper.clientWidth;
@@ -17,8 +17,15 @@ function init(headerEl) {
 		const currentSelection = wrapper.querySelector('[aria-current]');
 		if (currentSelection) {
 			let currentSelectionEnd = currentSelection.getBoundingClientRect().right;
+
+			//if the current selection is wider than the end of the wrapper
 			if (currentSelectionEnd > wrapperWidth) {
-				wrapper.scrollTo(currentSelectionEnd, 0);
+				// check by how much
+				let diff = currentSelectionEnd - wrapperWidth;
+				// if the difference is greater than half of the wrapper, scroll to the end of the current selection.
+				diff = (diff > wrapperWidth / 2) ? currentSelectionEnd : wrapperWidth / 2;
+
+				wrapper.scrollTo(diff, 0);
 			}
 
 			scrollable();

--- a/src/js/subnav.js
+++ b/src/js/subnav.js
@@ -17,15 +17,11 @@ function init(headerEl) {
 		const currentSelection = wrapper.querySelector('[aria-current]');
 		if (currentSelection) {
 			let currentSelectionEnd = currentSelection.getBoundingClientRect().right;
-
-			//if current selection is within wrapper bounds don't scroll, but show scroll options
-			if (currentSelectionEnd < wrapperWidth) {
-				scrollable();
-			// if current selection is not within wrapper bounds, scroll to it, _then_ show scroll options
-			} else {
+			if (currentSelectionEnd > wrapperWidth) {
 				wrapper.scrollTo(currentSelectionEnd, 0);
-				scrollable();
 			}
+
+			scrollable();
 		}
 	}
 

--- a/src/js/subnav.js
+++ b/src/js/subnav.js
@@ -8,18 +8,15 @@ function init(headerEl) {
 	}
 
 	const buttons = Array.from(subnav.getElementsByTagName('button'));
-
 	const wrapper = subnav.querySelector('[data-o-header-subnav-wrapper]');
-	const content = subnav.querySelector('.o-header__subnav-content')
 
+	let scrollWidth;
 	let wrapperWidth = wrapper.clientWidth;
-	let contentWidth = content.clientWidth;
 
 	function checkCurrentPosition() {
-		//get current selection
 		const currentSelection = wrapper.querySelector('[aria-current]');
 		if (currentSelection) {
-			let currentSelectionEnd =  currentSelection.getBoundingClientRect().right;
+			let currentSelectionEnd = currentSelection.getBoundingClientRect().right;
 
 			//if current selection is within wrapper bounds don't scroll, but show scroll options
 			if (currentSelectionEnd < wrapperWidth) {
@@ -37,7 +34,7 @@ function init(headerEl) {
 	}
 
 	function scrollable() {
-		let scrollWidth = wrapper.scrollWidth;
+		scrollWidth = wrapper.scrollWidth;
 
 		buttons.forEach(button => {
 			if (direction(button) === 'left') {

--- a/src/scss/features/_subnav.scss
+++ b/src/scss/features/_subnav.scss
@@ -34,6 +34,7 @@
 	.o-header__subnav-content {
 		white-space: nowrap;
 		margin-left: $_o-header-sub-header-focus-margin;
+		display: inline-block;
 	}
 
 	.o-header__subnav-list {


### PR DESCRIPTION
In response to an issue @draysonandstock raised in person:
The scroll arrows at mobile were flashing where there was no scrollable content, as shown below.
This was due to an incorrectly ordered calculation by o-header, and this PR removes it.

Before:  
![flash](https://user-images.githubusercontent.com/16777943/42511224-25708eba-8449-11e8-83de-1a497bd6c134.gif)

After:  
![no-flash](https://user-images.githubusercontent.com/16777943/42510909-43cd11ae-8448-11e8-81a8-ccdacc7e7bf0.gif)

