### PR TITLE
remove inline-block

### DIFF
--- a/src/scss/features/_subnav.scss
+++ b/src/scss/features/_subnav.scss
@@ -34,7 +34,6 @@
 	.o-header__subnav-content {
 		white-space: nowrap;
 		margin-left: $_o-header-sub-header-focus-margin;
-		display: inline-block;
 	}
 
 	.o-header__subnav-list {


### PR DESCRIPTION
This had an unexpected effect on the subnav in prod, so removing for now.