### PR TITLE
Reduce padding between main navigation items

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -10,7 +10,7 @@ $o-header-image-base-url: "https://www.ft.com/__origami/service/image" !default;
 $o-header-image-service-version: "v2" !default;
 
 
-$_o-header-padding-x: 16px;
+$_o-header-padding-x: 14px;
 $_o-header-padding-y: 8px;
 $_o-header-buttons-theme: 'primary-mono';
 $_o-header-mega-padding-x: 24px;


### PR DESCRIPTION
Since adding HTSI to the navigation the items can look a bit compressed against the right side navigation for "Portfolio" and "Account Settings".

This change just gives everything a little more space.

**Before**

![image](https://user-images.githubusercontent.com/51677/45740492-51463900-bbed-11e8-96ab-6077f0bbf12a.png)


**After**

![image](https://user-images.githubusercontent.com/51677/45740518-5c996480-bbed-11e8-91cf-8a4846a87277.png)

![image](https://user-images.githubusercontent.com/51677/45740531-6327dc00-bbed-11e8-8634-9728a9b2f0d6.png)

![image](https://user-images.githubusercontent.com/51677/45740544-691dbd00-bbed-11e8-8a0a-c41385b3d068.png)
