### PR TITLE
Decide to show buttons on load as well

### DIFF
--- a/demos/src/subnav.json
+++ b/demos/src/subnav.json
@@ -30,7 +30,7 @@
 			{
 				"name": "World",
 				"url": "#",
-				"selected": true
+				"selected": false
 			},
 			{
 				"name": "UK",
@@ -471,7 +471,7 @@
 			{
 				"name": "US Politics & Policy",
 				"href": "#",
-				"selected": true
+				"selected": false
 			},
 			{
 				"name": "US Companies",

--- a/demos/src/subnav.json
+++ b/demos/src/subnav.json
@@ -30,7 +30,7 @@
 			{
 				"name": "World",
 				"url": "#",
-				"selected": false
+				"selected": true
 			},
 			{
 				"name": "UK",
@@ -471,7 +471,7 @@
 			{
 				"name": "US Politics & Policy",
 				"href": "#",
-				"selected": false
+				"selected": true
 			},
 			{
 				"name": "US Companies",

--- a/src/js/subnav.js
+++ b/src/js/subnav.js
@@ -27,9 +27,8 @@ function init(headerEl) {
 
 				wrapper.scrollTo(diff, 0);
 			}
-
-			scrollable();
 		}
+		scrollable();
 	}
 
 	function direction(button) {


### PR DESCRIPTION
On load when a sub nav bar is wider than the window length the scroll buttons were not showing, the user could only see it was scrollable by scrolling it.

Fixes issue https://github.com/Financial-Times/o-header/issues/313 by calling `scrollable` on load as well as on scroll.