### PR TITLE
Increase subnav height for mobile

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -23,7 +23,7 @@ $_o-header-drawer-padding-x: 16px;
 $_o-header-drawer-padding-y: 12px;
 $_o-header-sticky-z-index: 99;
 $_o-header-sticky-height: 55px;
-$_o-header-subhav-height: 36px;
+$_o-header-subnav-height: 36px;
 $_o-header-item-separator-percentage-height: 0.7;
 $_o-header-sub-header-focus-margin: 5px;
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -23,7 +23,8 @@ $_o-header-drawer-padding-x: 16px;
 $_o-header-drawer-padding-y: 12px;
 $_o-header-sticky-z-index: 99;
 $_o-header-sticky-height: 55px;
-$_o-header-subnav-height: 36px;
+$_o-header-subnav-height-base: 44px;
+$_o-header-subnav-height-medium: 36px;
 $_o-header-item-separator-percentage-height: 0.7;
 $_o-header-sub-header-focus-margin: 5px;
 

--- a/src/scss/features/_subnav.scss
+++ b/src/scss/features/_subnav.scss
@@ -12,7 +12,10 @@
 			overflow: hidden;
 			// height *needs* setting so we can hide scrollbars.
 			// This is the content height of .o-header__subnav-content
-			height: $_o-header-subnav-height;
+			height: $_o-header-subnav-height-base;
+			@include oGridRespondTo('M') {
+				height: $_o-header-subnav-height-medium;
+			}
 		}
 	}
 
@@ -42,7 +45,7 @@
 		margin: 0;
 
 		// Separators for subnav lists are positioned relative to the subnavs first item
-		// to avoid positioning subnavs relative. This is so absolute childen of the subnav are
+		// to avoid positioning subnavs relative. This is so absolute children of the subnav are
 		// positioned relative to their closest positioned ancestor `o-header__container`.
 		// An example benefit is o-tooltip support against sub nav items.
 		& + & .o-header__subnav-item {
@@ -50,8 +53,12 @@
 				@include _oHeaderItemSeparatorContent();
 				&:before {
 					top: 50%;
-					margin-top: - $_o-header-subnav-height * $_o-header-item-separator-percentage-height / 2;
-					height: $_o-header-subnav-height * $_o-header-item-separator-percentage-height;
+					margin-top: - $_o-header-subnav-height-base * $_o-header-item-separator-percentage-height / 2;
+					height: $_o-header-subnav-height-base * $_o-header-item-separator-percentage-height;
+					@include oGridRespondTo('M') {
+						margin-top: - $_o-header-subnav-height-medium * $_o-header-item-separator-percentage-height / 2;
+						height: $_o-header-subnav-height-medium * $_o-header-item-separator-percentage-height;
+					}
 				}
 			}
 		}
@@ -91,7 +98,10 @@
 		@include oHeaderFancyLink;
 		color: _oHeaderGet('subnav-link');
 		display: inline-block;
-		padding: 8px 0;
+		padding: 12px 0;
+		@include oGridRespondTo('M') {
+			padding: 8px 0;
+		}
 
 		.o-header__subnav-list--breadcrumb & {
 			color: _oHeaderGet('link-highlight-text');

--- a/src/scss/features/_subnav.scss
+++ b/src/scss/features/_subnav.scss
@@ -12,7 +12,7 @@
 			overflow: hidden;
 			// height *needs* setting so we can hide scrollbars.
 			// This is the content height of .o-header__subnav-content
-			height: $_o-header-subhav-height;
+			height: $_o-header-subnav-height;
 		}
 	}
 
@@ -50,8 +50,8 @@
 				@include _oHeaderItemSeparatorContent();
 				&:before {
 					top: 50%;
-					margin-top: - $_o-header-subhav-height * $_o-header-item-separator-percentage-height / 2;
-					height: $_o-header-subhav-height * $_o-header-item-separator-percentage-height;
+					margin-top: - $_o-header-subnav-height * $_o-header-item-separator-percentage-height / 2;
+					height: $_o-header-subnav-height * $_o-header-item-separator-percentage-height;
 				}
 			}
 		}


### PR DESCRIPTION
Increase height of subnav for mobile viewports, to make the links more finger friendly in preparation for using it on myFT in the app. This is effectively a revert of #300. 

* [Trello ticket](https://trello.com/c/jKPNYUfH/1149-increase-size-of-o-header-subnav-on-mobile-breakpoints)
* [Slack convo about re-doing this](https://financialtimes.slack.com/archives/C8QEX3BEK/p1541089039032000)

