### PR TITLE
update font sizes and padding

### DIFF
--- a/demos/src/header.json
+++ b/demos/src/header.json
@@ -40,6 +40,10 @@
 				"url": "#"
 			},
 			{
+				"name": "Tech",
+				"url": "#"
+			},
+			{
 				"name": "Markets",
 				"url": "#"
 			},
@@ -54,9 +58,17 @@
 			{
 				"name": "Life & Arts",
 				"url": "#"
+			},
+			{
+				"name": "Graphics",
+				"url": "#"
+			},
+			{
+				"name": "How to spend it",
+				"url": "#"
 			}
 		],
-		"isSignedIn": false
+		"isSignedIn": true
 	},
 	"drawer": {
 		"nav": [

--- a/demos/src/subnav.json
+++ b/demos/src/subnav.json
@@ -25,12 +25,11 @@
 			{
 				"name": "Home",
 				"url": "#",
-				"selected": false
+				"selected": true
 			},
 			{
 				"name": "World",
-				"url": "#",
-				"selected": true
+				"url": "#"
 			},
 			{
 				"name": "UK",
@@ -38,6 +37,10 @@
 			},
 			{
 				"name": "Companies",
+				"url": "#"
+			},
+			{
+				"name": "Tech",
 				"url": "#"
 			},
 			{
@@ -55,9 +58,17 @@
 			{
 				"name": "Life & Arts",
 				"url": "#"
+			},
+			{
+				"name": "Graphics",
+				"url": "#"
+			},
+			{
+				"name": "How to spend it",
+				"url": "#"
 			}
 		],
-		"isSignedIn": false
+		"isSignedIn": true
 	},
 	"drawer": {
 		"nav": [

--- a/src/scss/features/_nav.scss
+++ b/src/scss/features/_nav.scss
@@ -1,7 +1,7 @@
 @mixin oHeaderNav() {
 	.o-header__nav {
-		@include oTypographySans(0);
-		@include oTypographyProgressiveFontFallback('sans', 0);
+		@include oTypographySans($scale: -1, $line-height: 20px);
+		@include oTypographyProgressiveFontFallback('sans', $scale: -1);
 	}
 
 	.o-header__nav--mobile {
@@ -37,7 +37,7 @@
 	.o-header__nav-item {
 		display: table-cell;
 		vertical-align: middle;
-		padding-left: $_o-header-padding-x;
+		padding-left: $_o-header-padding-x - 2;
 
 		&:first-child {
 			padding-left: 0;

--- a/src/scss/features/_nav.scss
+++ b/src/scss/features/_nav.scss
@@ -1,7 +1,6 @@
 @mixin oHeaderNav() {
 	.o-header__nav {
 		@include oTypographySans($scale: -1, $line-height: 20px);
-		@include oTypographyProgressiveFontFallback('sans', $scale: -1);
 	}
 
 	.o-header__nav--mobile {

--- a/src/scss/features/_subnav.scss
+++ b/src/scss/features/_subnav.scss
@@ -67,7 +67,7 @@
 	.o-header__subnav-item {
 		position: relative;
 		display: inline-block;
-		padding-left: 6px;
+		padding-left: 8px;
 
 		.o-header__subnav-list--children & {
 			padding-left: 16px;


### PR DESCRIPTION
This PR changes the font size for the main nav in the header, and the padding for both navigation bars. It drops the `font-size` to `14px` from `16px` and `padding-left` from `14px` to `12px`, according to Simon Coxon's design changes.

The need for this comes from the addition of elements in the main nav, that have broken the nav at the M viewport. 

**Before:**
<img width="983" alt="screen shot 2018-11-26 at 11 35 19" src="https://user-images.githubusercontent.com/16777943/49011850-76b46d80-f16f-11e8-855a-74f88b6f0367.png">

**After**
<img width="983" alt="screen shot 2018-11-26 at 11 32 28" src="https://user-images.githubusercontent.com/16777943/49011858-7c11b800-f16f-11e8-9afe-7f3aac29efd2.png">
