### PR TITLE
Revert "use ESM insteadof CJS"

### DIFF
--- a/demos/src/drawer.js
+++ b/demos/src/drawer.js
@@ -1,4 +1,4 @@
-export default function () {
+module.exports = function () {
 	const editionsData = {
 		current: {
 			name: 'UK',
@@ -392,4 +392,4 @@ export default function () {
 	};
 
 	return drawer;
-}
+};


### PR DESCRIPTION
Reverts Financial-Times/o-header#325