### PR TITLE
Wrap DOM manipulation in setTimeout to stop process blocking

### DIFF
--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -171,8 +171,13 @@ function init () {
 	addSubmenuToggles(drawerEl);
 	addDrawerToggles(drawerEl);
 
-	drawerEl.removeAttribute('data-o-header-drawer--no-js');
-	drawerEl.setAttribute('data-o-header-drawer--js', 'true');
+	// Wrap in a timeout to stop page load stall in Chrome v73 on Android
+	// toggleTabbing and the removal of the no-js attribute spikes the CPU
+	// and causes the main process to block for around 10 seconds.
+	setTimeout(() => {
+		drawerEl.removeAttribute('data-o-header-drawer--no-js');
+		drawerEl.setAttribute('data-o-header-drawer--js', 'true');
+	});
 }
 
 export default { init, handleCloseEvents };


### PR DESCRIPTION
In Chrome 73 on Android toggleTabbing and the removal of the no-js data attribute spikes the CPU and causes the main thread to block for around 10 seconds.

![load-profile 2019-04-03 14_04_03](https://user-images.githubusercontent.com/1721150/55481028-67f82e80-5619-11e9-843e-8903db20915c.gif)
