### PR TITLE
DAC - fix sign-out focus

### DIFF
--- a/src/scss/features/_subnav.scss
+++ b/src/scss/features/_subnav.scss
@@ -6,7 +6,7 @@
 	}
 
 	.o-header__subnav-wrap-outside {
-		margin-left: -$_o-header-sub-header-focus-margin;
+		margin: 0 -$_o-header-sub-header-focus-margin;
 
 		[data-o-header--js] & {
 			overflow: hidden;
@@ -36,7 +36,7 @@
 
 	.o-header__subnav-content {
 		white-space: nowrap;
-		margin-left: $_o-header-sub-header-focus-margin;
+		margin: 0 $_o-header-sub-header-focus-margin;
 	}
 
 	.o-header__subnav-list {


### PR DESCRIPTION
# DAC - fix sign-out focus
_NOTE_: I have no idea if this is the right way to fix this

https://docs.google.com/spreadsheets/d/1_Wp100e-2gwGQDxPS6YODqFsVRwycO9Y6PiXzppU-TY/edit?ts=5cd598dd#gid=2122682530 row 47

## What
Adds 2px padding to subheader right so that its outline doesn't escape the viewport when data-focus is applied

### FROM
<img width="936" alt="Screenshot 2019-06-18 at 14 25 22" src="https://user-images.githubusercontent.com/11778762/59688129-f28e0a00-91d4-11e9-90b5-109424f352af.png"> 

### TO
<img width="923" alt="Screenshot 2019-06-18 at 14 24 45" src="https://user-images.githubusercontent.com/11778762/59688139-f7eb5480-91d4-11e9-86ee-8fa80ac9e1d1.png">