### PR TITLE
Remove margin shorthand from focus offet CSS.

### DIFF
--- a/src/scss/features/_subnav.scss
+++ b/src/scss/features/_subnav.scss
@@ -6,7 +6,8 @@
 	}
 
 	.o-header__subnav-wrap-outside {
-		margin: 0 -$_o-header-sub-header-focus-margin;
+		margin-left: -$_o-header-sub-header-focus-margin;
+		margin-right: -$_o-header-sub-header-focus-margin;
 
 		[data-o-header--js] & {
 			overflow: hidden;
@@ -36,7 +37,8 @@
 
 	.o-header__subnav-content {
 		white-space: nowrap;
-		margin: 0 $_o-header-sub-header-focus-margin;
+		margin-left: $_o-header-sub-header-focus-margin;
+		margin-right: $_o-header-sub-header-focus-margin;
 	}
 
 	.o-header__subnav-list {


### PR DESCRIPTION
It appears Next's critical CSS generator is [not including the
shorthand correctly](https://github.com/Financial-Times/o-header/pull/336#issuecomment-507298560). Whilst we investigate use the long form 
`margin-left` and `margin-right`.