### PR TITLE
add list-style-type:none to nav-list for a11y purposes

### DIFF
--- a/src/scss/features/_nav.scss
+++ b/src/scss/features/_nav.scss
@@ -21,6 +21,7 @@
 
 	.o-header__nav-list {
 		display: table;
+		list-style-type: none;
 		margin: 0 auto;
 		padding: 0;
 	}


### PR DESCRIPTION
without this, screenreaders treat it as an actual list and read `bullet` before each item