### PR TITLE
Only visually hide "top link label", instead of setting `display: none`.

### DIFF
--- a/src/scss/features/_top.scss
+++ b/src/scss/features/_top.scss
@@ -118,11 +118,7 @@
 	}
 
 	.o-header__top-link-label {
-		/* Deprecate this label in next breaking release (v7), but for v6.12.0
-		display-none it so that layout won't break and people don't have
-		to update their markup to get the change
-		*/
-		display: none;
+		@include oNormaliseVisuallyHidden;
 	}
 
 	.o-header__top-logo {


### PR DESCRIPTION
The title attribute is good, but not enough:

>[The title attribute approach] is generally less reliable and not recommended because some screen readers and assistive technologies do not interpret the title attribute as a replacement for the label element, possibly because the title attribute is often used to provide non-essential information. The information of the title attribute is shown to visual users as a tool tip when hovering over the form field with the mouse

https://www.w3.org/WAI/tutorials/forms/labels/#using-aria-label