### PR TITLE
Put current link in subnav demo into the breadcrumb.

### DIFF
--- a/demos/src/subnav.json
+++ b/demos/src/subnav.json
@@ -468,6 +468,7 @@
 	"subnav": true,
 	"currentNav": {
 		"name": "US & Canada",
+		"selected": true,
 		"ancestors": [
 			{
 				"name": "World",
@@ -481,8 +482,7 @@
 			},
 			{
 				"name": "US Politics & Policy",
-				"href": "#",
-				"selected": true
+				"href": "#"
 			},
 			{
 				"name": "US Companies",

--- a/demos/src/subnav.mustache
+++ b/demos/src/subnav.mustache
@@ -57,7 +57,7 @@
 							{{/currentNav.ancestors}}
 							{{#currentNav}}
 							<li class="o-header__subnav-item">
-								<a class="o-header__subnav-link" href="{{href}}" >
+								<a class="o-header__subnav-link" href="{{href}}" {{#selected}}aria-current="page" aria-label="Current page"{{/selected}}>
 									{{name}}
 								</a>
 							</li>


### PR DESCRIPTION
At time of writing, ft.com always put current pages in the
breadcrumb, even when there are no more child pages. To avoid
confusion show the current page as a breadcrumb in the o-header
subnav demo.

Before "US Politics..." was shown as the current page:
<img width="1520" alt="Screenshot 2020-01-15 at 16 18 34" src="https://user-images.githubusercontent.com/10405691/72450896-03c2e780-37b3-11ea-898f-d7275e77a19f.png">

Now "US & Canada" is shown as the current page:
<img width="1520" alt="Screenshot 2020-01-15 at 16 18 37" src="https://user-images.githubusercontent.com/10405691/72450897-03c2e780-37b3-11ea-8a54-f68330febd06.png">


This is how ft.com currently uses o-header:
<img width="1520" alt="Screenshot 2020-01-15 at 16 22 23" src="https://user-images.githubusercontent.com/10405691/72451063-497fb000-37b3-11ea-8798-c687430f988c.png">
<img width="1520" alt="Screenshot 2020-01-15 at 16 22 35" src="https://user-images.githubusercontent.com/10405691/72451065-497fb000-37b3-11ea-9394-4994ca207e55.png">
