### PR TITLE
Use dummy navigation data in demos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # o-header [![CircleCI](https://circleci.com/gh/Financial-Times/o-header.png?style=shield&circle-token=41f2b7b7e669f2d4adb55ad97cf755d3ed4b93c3)](https://circleci.com/gh/Financial-Times/o-header) [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
 
-Responsive header for FT branded sites
+Responsive header for FT branded sites. See the [Origami Navigation Service](https://www.ft.com/__origami/service/navigation) to populate `o-header` markup with real navigation data.
 
 - [Markup](#markup)
 - [JavaScript](#JavaScript)
@@ -12,7 +12,7 @@ Responsive header for FT branded sites
 
 ## Markup
 
-As there are variations on the header, and the markup for each is specific and somewhat extensive, we recommend visiting the [component page](http://registry.origami.ft.com/components/o-header) in the registry to find the markup that is most suited to your product.
+As there are variations on the header, and the markup for each is specific and somewhat extensive, we recommend visiting the [component page](http://registry.origami.ft.com/components/o-header) in the registry to find the markup that is most suited to your product. The demo on the component page does not use real navigation data as it may become out of date. See the [Origami Navigation Service](https://www.ft.com/__origami/service/navigation) to populate `o-header` markup with real navigation data. The Origami Navigation Service is a JSON API which provides navigation structures for use across FT websites.
 
 _There are intentionally no classes to switch between logged in and out as we don't want to do that in the client side. This is left up to the product._
 

--- a/demos/src/header.json
+++ b/demos/src/header.json
@@ -1,468 +1,468 @@
 {
-	"anon": true,
-	"top": {
-		"hasMenu": true,
-		"hasMyFT": true
-	},
-	"search": true,
-	"nav": {
-		"mobile": [
-			{
-				"name": "Home",
-				"url": "#",
-				"selected": true
-			},
-			{
-				"name": "FastFT",
-				"url": "#"
-			},
-			{
-				"name": "Markets Data",
-				"url": "#"
-			}
-		],
-		"desktop": [
-			{
-				"name": "Home",
-				"url": "#",
-				"selected": true
-			},
-			{
-				"name": "World",
-				"url": "#"
-			},
-			{
-				"name": "UK",
-				"url": "#"
-			},
-			{
-				"name": "Companies",
-				"url": "#"
-			},
-			{
-				"name": "Tech",
-				"url": "#"
-			},
-			{
-				"name": "Markets",
-				"url": "#"
-			},
-			{
-				"name": "Opinion",
-				"url": "#"
-			},
-			{
-				"name": "Work & Careers",
-				"url": "#"
-			},
-			{
-				"name": "Life & Arts",
-				"url": "#"
-			},
-			{
-				"name": "Graphics",
-				"url": "#"
-			},
-			{
-				"name": "How to spend it",
-				"url": "#"
-			}
-		],
-		"isSignedIn": true
-	},
-	"drawer": {
-		"nav": [
-			{
-				"heading": {
-					"name": "Top sections"
-				},
-				"items": [
-					{
-						"name": "Home",
-						"href": "#",
-						"selected": true,
-						"index": 0
-					},
-					{
-						"name": "World",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "World Economy",
-								"href": "#"
-							},
-							{
-								"name": "UK",
-								"href": "#"
-							},
-							{
-								"name": "US",
-								"href": "#"
-							},
-							{
-								"name": "China",
-								"href": "#"
-							},
-							{
-								"name": "Africa",
-								"href": "#"
-							},
-							{
-								"name": "Asia Pacific",
-								"href": "#"
-							},
-							{
-								"name": "Emerging Markets",
-								"href": "#"
-							},
-							{
-								"name": "Europe",
-								"href": "#"
-							},
-							{
-								"name": "Latin America",
-								"href": "#"
-							},
-							{
-								"name": "Middle East and Africa",
-								"href": "#"
-							}
-						],
-						"index": 1
-					},
-					{
-						"name": "UK",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "UK Economy",
-								"href": "#"
-							},
-							{
-								"name": "UK Politics & Policy",
-								"href": "#"
-							},
-							{
-								"name": "UK Companies",
-								"href": "#"
-							}
-						],
-						"index": 2
-					},
-					{
-						"name": "Companies",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "Energy",
-								"href": "#"
-							},
-							{
-								"name": "Financials",
-								"href": "#"
-							},
-							{
-								"name": "Health",
-								"href": "#"
-							},
-							{
-								"name": "Industrials",
-								"href": "#"
-							},
-							{
-								"name": "Media",
-								"href": "#"
-							},
-							{
-								"name": "Retail & Consumer",
-								"href": "#"
-							},
-							{
-								"name": "Technology",
-								"href": "#"
-							},
-							{
-								"name": "Telecoms",
-								"href": "#"
-							},
-							{
-								"name": "Transport",
-								"href": "#"
-							}
-						],
-						"index": 3
-					},
-					{
-						"name": "Markets",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "Alphaville",
-								"href": "#"
-							},
-							{
-								"name": "Markets Data",
-								"href": "#"
-							},
-							{
-								"name": "Capital Markets",
-								"href": "#"
-							},
-							{
-								"name": "Commodities",
-								"href": "#"
-							},
-							{
-								"name": "Currencies",
-								"href": "#"
-							},
-							{
-								"name": "Equities",
-								"href": "#"
-							},
-							{
-								"name": "Fund Management",
-								"href": "#"
-							},
-							{
-								"name": "Trading",
-								"href": "#"
-							}
-						],
-						"index": 4
-					},
-					{
-						"name": "Opinion",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "Columnists",
-								"href": "#"
-							},
-							{
-								"name": "FT View",
-								"href": "#"
-							},
-							{
-								"name": "The Big Read",
-								"href": "#"
-							},
-							{
-								"name": "Lex",
-								"href": "#"
-							},
-							{
-								"name": "Alphaville",
-								"href": "#"
-							},
-							{
-								"name": "Obituaries",
-								"href": "#"
-							},
-							{
-								"name": "Letters",
-								"href": "#"
-							}
-						],
-						"index": 5
-					},
-					{
-						"name": "Work & Careers",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "Business School Rankings",
-								"href": "#"
-							},
-							{
-								"name": "Business Education",
-								"href": "#"
-							},
-							{
-								"name": "Entrepreneurship",
-								"href": "#"
-							},
-							{
-								"name": "Recruitment",
-								"href": "#"
-							},
-							{
-								"name": "Business Books",
-								"href": "#"
-							}
-						],
-						"index": 6
-					},
-					{
-						"name": "Life & Arts",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "House & Home",
-								"href": "#"
-							},
-							{
-								"name": "Books",
-								"href": "#"
-							},
-							{
-								"name": "Food & Drink",
-								"href": "#"
-							},
-							{
-								"name": "Travel",
-								"href": "#"
-							},
-							{
-								"name": "Style",
-								"href": "#"
-							},
-							{
-								"name": "Arts",
-								"href": "#"
-							},
-							{
-								"name": "Sports",
-								"href": "#"
-							},
-							{
-								"name": "Music",
-								"href": "#"
-							},
-							{
-								"name": "Film, TV & Radio",
-								"href": "#"
-							},
-							{
-								"name": "Magazine",
-								"href": "#"
-							}
-						],
-						"index": 7
-					},
-					{
-						"name": "Personal Finance",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "Property & Mortgages",
-								"href": "#"
-							},
-							{
-								"name": "Investments",
-								"href": "#"
-							},
-							{
-								"name": "Pensions",
-								"href": "#"
-							},
-							{
-								"name": "Tax",
-								"href": "#"
-							},
-							{
-								"name": "Bankings & Savings",
-								"href": "#"
-							}
-						],
-						"index": 8
-					},
-					{
-						"name": "Science & Environment",
-						"href": "#",
-						"index": 9
-					}
-				]
-			},
-			{
-				"heading": {
-					"name": "FT recommends"
-				},
-				"items": [
-					{
-						"name": "Lex",
-						"href": "#",
-						"index": 0
-					},
-					{
-						"name": "Alphaville",
-						"href": "#",
-						"index": 1
-					},
-					{
-						"name": "Lunch with the FT",
-						"href": "#",
-						"index": 2
-					},
-					{
-						"name": "Video",
-						"href": "#",
-						"index": 3
-					},
-					{
-						"name": "Special Reports",
-						"href": "#",
-						"index": 4
-					},
-					{
-						"name": "News feed",
-						"href": "#",
-						"index": 5
-					},
-					{
-						"name": "Newsletters",
-						"href": "#",
-						"index": 6
-					}
-				]
-			},
-			{
-				"items": [
-					{
-						"name": "My FT",
-						"href": "#",
-						"variation": "secondary",
-						"divide": true,
-						"index": 0
-					},
-					{
-						"name": "Portfolio",
-						"href": "#",
-						"variation": "secondary",
-						"index": 1
-					},
-					{
-						"name": "Today's Paper",
-						"href": "#",
-						"variation": "secondary",
-						"index": 2
-					}
-				]
-			}
-		],
-		"editions": {
-			"current": {
-				"name": "UK",
-				"id": "uk"
-			},
-			"others": [
-				{
-					"name": "International",
-					"id": "international"
-				}
-			]
-		},
-		"user": {
-			"isSignedIn": false,
-			"name": "User's name"
-		}
-	}
+    "anon": true,
+    "top": {
+        "hasMenu": true,
+        "hasMyFT": true
+    },
+    "search": true,
+    "nav": {
+        "mobile": [
+            {
+                "name": "xxxx",
+                "url": "#",
+                "selected": true
+            },
+            {
+                "name": "xxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxxxxx xxxx",
+                "url": "#"
+            }
+        ],
+        "desktop": [
+            {
+                "name": "xxxx",
+                "url": "#",
+                "selected": true
+            },
+            {
+                "name": "xxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xx",
+                "url": "#"
+            },
+            {
+                "name": "xxxxxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxx x xxxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxx x xxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxx xx xxxxx xx",
+                "url": "#"
+            }
+        ],
+        "isSignedIn": true
+    },
+    "drawer": {
+        "nav": [
+            {
+                "heading": {
+                    "name": "xxx xxxxxxxx"
+                },
+                "items": [
+                    {
+                        "name": "xxxx",
+                        "href": "#",
+                        "selected": true,
+                        "index": 0
+                    },
+                    {
+                        "name": "xxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx xxxx xxx xxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 1
+                    },
+                    {
+                        "name": "xx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx xxxxxxxx x xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx xxxxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 2
+                    },
+                    {
+                        "name": "xxxxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx x xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 3
+                    },
+                    {
+                        "name": "xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 4
+                    },
+                    {
+                        "name": "xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxx xxx xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 5
+                    },
+                    {
+                        "name": "xxxx x xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxx xxxxxx xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx xxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx xxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 6
+                    },
+                    {
+                        "name": "xxxx x xxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxx x xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx x xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx xx x xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 7
+                    },
+                    {
+                        "name": "xxxxxxxx xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxx x xxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx x xxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 8
+                    },
+                    {
+                        "name": "xxxxxxx x xxxxxxxxxxx",
+                        "href": "#",
+                        "index": 9
+                    }
+                ]
+            },
+            {
+                "heading": {
+                    "name": "xx xxxxxxxxxx"
+                },
+                "items": [
+                    {
+                        "name": "xxx",
+                        "href": "#",
+                        "index": 0
+                    },
+                    {
+                        "name": "xxxxxxxxxx",
+                        "href": "#",
+                        "index": 1
+                    },
+                    {
+                        "name": "xxxxx xxxx xxx xx",
+                        "href": "#",
+                        "index": 2
+                    },
+                    {
+                        "name": "xxxxx",
+                        "href": "#",
+                        "index": 3
+                    },
+                    {
+                        "name": "xxxxxxx xxxxxxx",
+                        "href": "#",
+                        "index": 4
+                    },
+                    {
+                        "name": "xxxx xxxx",
+                        "href": "#",
+                        "index": 5
+                    },
+                    {
+                        "name": "xxxxxxxxxxx",
+                        "href": "#",
+                        "index": 6
+                    }
+                ]
+            },
+            {
+                "items": [
+                    {
+                        "name": "xx xx",
+                        "href": "#",
+                        "variation": "secondary",
+                        "divide": true,
+                        "index": 0
+                    },
+                    {
+                        "name": "xxxxxxxxx",
+                        "href": "#",
+                        "variation": "secondary",
+                        "index": 1
+                    },
+                    {
+                        "name": "xxxxxxx xxxxx",
+                        "href": "#",
+                        "variation": "secondary",
+                        "index": 2
+                    }
+                ]
+            }
+        ],
+        "editions": {
+            "current": {
+                "name": "xx",
+                "id": "uk"
+            },
+            "others": [
+                {
+                    "name": "xxxxxxxxxxxxx",
+                    "id": "international"
+                }
+            ]
+        },
+        "user": {
+            "isSignedIn": false,
+            "name": "xxxxxx xxxx"
+        }
+    }
 }

--- a/demos/src/mega-menu.json
+++ b/demos/src/mega-menu.json
@@ -1,863 +1,863 @@
 {
-	"anon": true,
-	"top": {
-		"hasMenu": true,
-		"hasMyFT": true
-	},
-	"search": true,
-	"nav": {
-		"mobile": [
-			{
-				"name": "Home",
-				"url": "#",
-				"selected": true
-			},
-			{
-				"name": "FastFT",
-				"url": "#"
-			},
-			{
-				"name": "Markets Data",
-				"url": "#"
-			}
-		],
-		"desktop": [
-			{
-				"name": "Home",
-				"url": "#",
-				"selected": true,
-				"index": 0
-			},
-			{
-				"name": "World",
-				"url": "#",
-				"index": 1,
-				"hasMega": true,
-				"articles": [
-					{
-						"title": "The UK expats voting for Brexit no matter what the cost",
-						"url": "#"
-					},
-					{
-						"title": "Lunch with the FT: Adair Turner",
-						"url": "#"
-					},
-					{
-						"title": "English carpenter who makes beehives that sell across the world",
-						"url": "#"
-					},
-					{
-						"title": "French ambassador urges UK to help shape a ‘reformed Europe’",
-						"url": "#"
-					},
-					{
-						"title": "Where do politicians live? How MPs across the world find city digs",
-						"url": "#"
-					}
-				],
-				"subsections": [
-					{
-						"name": "All World",
-						"url": "#"
-					},
-					{
-						"name": "World Economy",
-						"url": "#"
-					},
-					{
-						"name": "US",
-						"url": "#"
-					},
-					{
-						"name": "Europe",
-						"url": "#"
-					},
-					{
-						"name": "Latin America",
-						"url": "#"
-					},
-					{
-						"name": "Asia Pacific",
-						"url": "#"
-					},
-					{
-						"name": "Africa",
-						"url": "#"
-					},
-					{
-						"name": "Middle East and Africa",
-						"url": "#"
-					},
-					{
-						"name": "Emerging Markets",
-						"url": "#"
-					},
-					{
-						"name": "Science & Environment",
-						"url": "#"
-					}
-				]
-			},
-			{
-				"name": "UK",
-				"url": "#",
-				"index": 2,
-				"hasMega": true,
-				"articles": [
-					{
-						"title": "The UK expats voting for Brexit no matter what the cost",
-						"url": "#"
-					},
-					{
-						"title": "Lunch with the FT: Adair Turner",
-						"url": "#"
-					},
-					{
-						"title": "English carpenter who makes beehives that sell across the world",
-						"url": "#"
-					},
-					{
-						"title": "French ambassador urges UK to help shape a ‘reformed Europe’",
-						"url": "#"
-					},
-					{
-						"title": "Where do politicians live? How MPs across the world find city digs",
-						"url": "#"
-					}
-				],
-				"subsections": [
-					{
-						"name": "All UK",
-						"url": "#"
-					},
-					{
-						"name": "UK Politics & Policy",
-						"url": "#"
-					},
-					{
-						"name": "UK Economy",
-						"url": "#"
-					},
-					{
-						"name": "England",
-						"url": "#"
-					},
-					{
-						"name": "Scotland",
-						"url": "#"
-					},
-					{
-						"name": "Wales",
-						"url": "#"
-					},
-					{
-						"name": "N. Ireland",
-						"url": "#"
-					}
-				]
-			},
-			{
-				"name": "Companies",
-				"url": "#",
-				"index": 3,
-				"hasMega": true,
-				"articles": [
-					{
-						"title": "The UK expats voting for Brexit no matter what the cost",
-						"url": "#"
-					},
-					{
-						"title": "Lunch with the FT: Adair Turner",
-						"url": "#"
-					},
-					{
-						"title": "English carpenter who makes beehives that sell across the world",
-						"url": "#"
-					},
-					{
-						"title": "French ambassador urges UK to help shape a ‘reformed Europe’",
-						"url": "#"
-					},
-					{
-						"title": "Where do politicians live? How MPs across the world find city digs",
-						"url": "#"
-					}
-				],
-				"subsections": [
-					{
-						"name": "All Companies",
-						"url": "#"
-					},
-					{
-						"name": "Technology",
-						"url": "#"
-					},
-					{
-						"name": "Financials",
-						"url": "#"
-					},
-					{
-						"name": "Energy",
-						"url": "#"
-					},
-					{
-						"name": "Retail & Consumer",
-						"url": "#"
-					},
-					{
-						"name": "Industrials",
-						"url": "#"
-					},
-					{
-						"name": "Telecoms",
-						"url": "#"
-					},
-					{
-						"name": "Health",
-						"url": "#"
-					},
-					{
-						"name": "Media",
-						"url": "#"
-					},
-					{
-						"name": "Transport",
-						"url": "#"
-					}
-				]
-			},
-			{
-				"name": "Markets",
-				"url": "#",
-				"index": 4,
-				"hasMega": true,
-				"articles": [
-					{
-						"title": "The UK expats voting for Brexit no matter what the cost",
-						"url": "#"
-					},
-					{
-						"title": "Lunch with the FT: Adair Turner",
-						"url": "#"
-					},
-					{
-						"title": "English carpenter who makes beehives that sell across the world",
-						"url": "#"
-					},
-					{
-						"title": "French ambassador urges UK to help shape a ‘reformed Europe’",
-						"url": "#"
-					},
-					{
-						"title": "Where do politicians live? How MPs across the world find city digs",
-						"url": "#"
-					}
-				],
-				"subsections": [
-					{
-						"name": "All Markets",
-						"url": "#"
-					},
-					{
-						"name": "Markets Data",
-						"url": "#"
-					},
-					{
-						"name": "Commodities",
-						"url": "#"
-					},
-					{
-						"name": "Currencies",
-						"url": "#"
-					},
-					{
-						"name": "Equities",
-						"url": "#"
-					},
-					{
-						"name": "Capital Markets",
-						"url": "#"
-					},
-					{
-						"name": "Trading",
-						"url": "#"
-					}
-				]
-			},
-			{
-				"name": "Opinion",
-				"url": "#",
-				"index": 5,
-				"hasMega": true,
-				"articles": [
-					{
-						"title": "The UK expats voting for Brexit no matter what the cost",
-						"url": "#"
-					},
-					{
-						"title": "Lunch with the FT: Adair Turner",
-						"url": "#"
-					},
-					{
-						"title": "English carpenter who makes beehives that sell across the world",
-						"url": "#"
-					},
-					{
-						"title": "French ambassador urges UK to help shape a ‘reformed Europe’",
-						"url": "#"
-					},
-					{
-						"title": "Where do politicians live? How MPs across the world find city digs",
-						"url": "#"
-					}
-				],
-				"subsections": [
-					{
-						"name": "All Opinion",
-						"url": "#"
-					},
-					{
-						"name": "FT View",
-						"url": "#"
-					},
-					{
-						"name": "The Big Read",
-						"url": "#"
-					},
-					{
-						"name": "Lex",
-						"url": "#"
-					},
-					{
-						"name": "Columnists",
-						"url": "#"
-					}
-				]
-			},
-			{
-				"name": "Work & Careers",
-				"url": "#",
-				"index": 6,
-				"hasMega": true,
-				"articles": [
-					{
-						"title": "The UK expats voting for Brexit no matter what the cost",
-						"url": "#"
-					},
-					{
-						"title": "Lunch with the FT: Adair Turner",
-						"url": "#"
-					},
-					{
-						"title": "English carpenter who makes beehives that sell across the world",
-						"url": "#"
-					},
-					{
-						"title": "French ambassador urges UK to help shape a ‘reformed Europe’",
-						"url": "#"
-					},
-					{
-						"title": "Where do politicians live? How MPs across the world find city digs",
-						"url": "#"
-					}
-				],
-				"subsections": [
-					{
-						"name": "All Work & Career",
-						"url": "#"
-					},
-					{
-						"name": "Business Education",
-						"url": "#"
-					},
-					{
-						"name": "Management",
-						"url": "#"
-					},
-					{
-						"name": "Entrepreneurship",
-						"url": "#"
-					},
-					{
-						"name": "Recruitment",
-						"url": "#"
-					},
-					{
-						"name": "Business Books",
-						"url": "#"
-					}
-				]
-			},
-			{
-				"name": "Life & Arts",
-				"url": "#",
-				"index": 7,
-				"hasMega": true,
-				"articles": [
-					{
-						"title": "The UK expats voting for Brexit no matter what the cost",
-						"url": "#"
-					},
-					{
-						"title": "Lunch with the FT: Adair Turner",
-						"url": "#"
-					},
-					{
-						"title": "English carpenter who makes beehives that sell across the world",
-						"url": "#"
-					},
-					{
-						"title": "French ambassador urges UK to help shape a ‘reformed Europe’",
-						"url": "#"
-					},
-					{
-						"title": "Where do politicians live? How MPs across the world find city digs",
-						"url": "#"
-					}
-				],
-				"subsections": [
-					{
-						"name": "All Life & Arts",
-						"url": "#"
-					},
-					{
-						"name": "Magazine",
-						"url": "#"
-					},
-					{
-						"name": "House & Home",
-						"url": "#"
-					},
-					{
-						"name": "Books",
-						"url": "#"
-					},
-					{
-						"name": "Food & Drink",
-						"url": "#"
-					},
-					{
-						"name": "Travel",
-						"url": "#"
-					},
-					{
-						"name": "Style",
-						"url": "#"
-					},
-					{
-						"name": "Arts",
-						"url": "#"
-					},
-					{
-						"name": "Sports",
-						"url": "#"
-					},
-					{
-						"name": "Music",
-						"url": "#"
-					},
-					{
-						"name": "Film, TV & Radio",
-						"url": "#"
-					}
-				]
-			}
-		],
-		"isSignedIn": false
-	},
-	"drawer": {
-		"nav": [
-			{
-				"heading": {
-					"name": "Top sections"
-				},
-				"items": [
-					{
-						"name": "Home",
-						"href": "#",
-						"selected": true,
-						"index": 0
-					},
-					{
-						"name": "World",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "World Economy",
-								"href": "#"
-							},
-							{
-								"name": "UK",
-								"href": "#"
-							},
-							{
-								"name": "US",
-								"href": "#"
-							},
-							{
-								"name": "China",
-								"href": "#"
-							},
-							{
-								"name": "Africa",
-								"href": "#"
-							},
-							{
-								"name": "Asia Pacific",
-								"href": "#"
-							},
-							{
-								"name": "Emerging Markets",
-								"href": "#"
-							},
-							{
-								"name": "Europe",
-								"href": "#"
-							},
-							{
-								"name": "Latin America",
-								"href": "#"
-							},
-							{
-								"name": "Middle East and Africa",
-								"href": "#"
-							}
-						],
-						"index": 1
-					},
-					{
-						"name": "UK",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "UK Economy",
-								"href": "#"
-							},
-							{
-								"name": "UK Politics & Policy",
-								"href": "#"
-							},
-							{
-								"name": "UK Companies",
-								"href": "#"
-							}
-						],
-						"index": 2
-					},
-					{
-						"name": "Companies",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "Energy",
-								"href": "#"
-							},
-							{
-								"name": "Financials",
-								"href": "#"
-							},
-							{
-								"name": "Health",
-								"href": "#"
-							},
-							{
-								"name": "Industrials",
-								"href": "#"
-							},
-							{
-								"name": "Media",
-								"href": "#"
-							},
-							{
-								"name": "Retail & Consumer",
-								"href": "#"
-							},
-							{
-								"name": "Technology",
-								"href": "#"
-							},
-							{
-								"name": "Telecoms",
-								"href": "#"
-							},
-							{
-								"name": "Transport",
-								"href": "#"
-							}
-						],
-						"index": 3
-					},
-					{
-						"name": "Markets",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "Alphaville",
-								"href": "#"
-							},
-							{
-								"name": "Markets Data",
-								"href": "#"
-							},
-							{
-								"name": "Capital Markets",
-								"href": "#"
-							},
-							{
-								"name": "Commodities",
-								"href": "#"
-							},
-							{
-								"name": "Currencies",
-								"href": "#"
-							},
-							{
-								"name": "Equities",
-								"href": "#"
-							},
-							{
-								"name": "Fund Management",
-								"href": "#"
-							},
-							{
-								"name": "Trading",
-								"href": "#"
-							}
-						],
-						"index": 4
-					},
-					{
-						"name": "Opinion",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "Columnists",
-								"href": "#"
-							},
-							{
-								"name": "FT View",
-								"href": "#"
-							},
-							{
-								"name": "The Big Read",
-								"href": "#"
-							},
-							{
-								"name": "Lex",
-								"href": "#"
-							},
-							{
-								"name": "Alphaville",
-								"href": "#"
-							},
-							{
-								"name": "Obituaries",
-								"href": "#"
-							},
-							{
-								"name": "Letters",
-								"href": "#"
-							}
-						],
-						"index": 5
-					},
-					{
-						"name": "Work & Careers",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "Business School Rankings",
-								"href": "#"
-							},
-							{
-								"name": "Business Education",
-								"href": "#"
-							},
-							{
-								"name": "Entrepreneurship",
-								"href": "#"
-							},
-							{
-								"name": "Recruitment",
-								"href": "#"
-							},
-							{
-								"name": "Business Books",
-								"href": "#"
-							}
-						],
-						"index": 6
-					},
-					{
-						"name": "Life & Arts",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "House & Home",
-								"href": "#"
-							},
-							{
-								"name": "Books",
-								"href": "#"
-							},
-							{
-								"name": "Food & Drink",
-								"href": "#"
-							},
-							{
-								"name": "Travel",
-								"href": "#"
-							},
-							{
-								"name": "Style",
-								"href": "#"
-							},
-							{
-								"name": "Arts",
-								"href": "#"
-							},
-							{
-								"name": "Sports",
-								"href": "#"
-							},
-							{
-								"name": "Music",
-								"href": "#"
-							},
-							{
-								"name": "Film, TV & Radio",
-								"href": "#"
-							},
-							{
-								"name": "Magazine",
-								"href": "#"
-							}
-						],
-						"index": 7
-					},
-					{
-						"name": "Personal Finance",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "Property & Mortgages",
-								"href": "#"
-							},
-							{
-								"name": "Investments",
-								"href": "#"
-							},
-							{
-								"name": "Pensions",
-								"href": "#"
-							},
-							{
-								"name": "Tax",
-								"href": "#"
-							},
-							{
-								"name": "Bankings & Savings",
-								"href": "#"
-							}
-						],
-						"index": 8
-					},
-					{
-						"name": "Science & Environment",
-						"href": "#",
-						"index": 9
-					}
-				]
-			},
-			{
-				"heading": {
-					"name": "FT recommends"
-				},
-				"items": [
-					{
-						"name": "Lex",
-						"href": "#",
-						"index": 0
-					},
-					{
-						"name": "Alphaville",
-						"href": "#",
-						"index": 1
-					},
-					{
-						"name": "Lunch with the FT",
-						"href": "#",
-						"index": 2
-					},
-					{
-						"name": "Video",
-						"href": "#",
-						"index": 3
-					},
-					{
-						"name": "Special Reports",
-						"href": "#",
-						"index": 4
-					},
-					{
-						"name": "News feed",
-						"href": "#",
-						"index": 5
-					},
-					{
-						"name": "Newsletters",
-						"href": "#",
-						"index": 6
-					}
-				]
-			},
-			{
-				"items": [
-					{
-						"name": "My FT",
-						"href": "#",
-						"variation": "secondary",
-						"divide": true,
-						"index": 0
-					},
-					{
-						"name": "Portfolio",
-						"href": "#",
-						"variation": "secondary",
-						"index": 1
-					},
-					{
-						"name": "Today's Paper",
-						"href": "#",
-						"variation": "secondary",
-						"index": 2
-					}
-				]
-			}
-		],
-		"editions": {
-			"current": {
-				"name": "UK",
-				"id": "uk"
-			},
-			"others": [
-				{
-					"name": "International",
-					"id": "international"
-				}
-			]
-		},
-		"user": {
-			"isSignedIn": false,
-			"name": "User's name"
-		}
-	}
+    "anon": true,
+    "top": {
+        "hasMenu": true,
+        "hasMyFT": true
+    },
+    "search": true,
+    "nav": {
+        "mobile": [
+            {
+                "name": "xxxx",
+                "url": "#",
+                "selected": true
+            },
+            {
+                "name": "xxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxxxxx xxxx",
+                "url": "#"
+            }
+        ],
+        "desktop": [
+            {
+                "name": "xxxx",
+                "url": "#",
+                "selected": true,
+                "index": 0
+            },
+            {
+                "name": "xxxxx",
+                "url": "#",
+                "index": 1,
+                "hasMega": true,
+                "articles": [
+                    {
+                        "title": "The UK expats voting for Brexit no matter what the cost",
+                        "url": "#"
+                    },
+                    {
+                        "title": "Lunch with the FT: Adair Turner",
+                        "url": "#"
+                    },
+                    {
+                        "title": "English carpenter who makes beehives that sell across the world",
+                        "url": "#"
+                    },
+                    {
+                        "title": "French ambassador urges UK to help shape a ‘reformed Europe’",
+                        "url": "#"
+                    },
+                    {
+                        "title": "Where do politicians live? How MPs across the world find city digs",
+                        "url": "#"
+                    }
+                ],
+                "subsections": [
+                    {
+                        "name": "xxx xxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxx xxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxx xxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxx xxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxx xxxx xxx xxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxx xxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxx x xxxxxxxxxxx",
+                        "url": "#"
+                    }
+                ]
+            },
+            {
+                "name": "xx",
+                "url": "#",
+                "index": 2,
+                "hasMega": true,
+                "articles": [
+                    {
+                        "title": "The UK expats voting for Brexit no matter what the cost",
+                        "url": "#"
+                    },
+                    {
+                        "title": "Lunch with the FT: Adair Turner",
+                        "url": "#"
+                    },
+                    {
+                        "title": "English carpenter who makes beehives that sell across the world",
+                        "url": "#"
+                    },
+                    {
+                        "title": "French ambassador urges UK to help shape a ‘reformed Europe’",
+                        "url": "#"
+                    },
+                    {
+                        "title": "Where do politicians live? How MPs across the world find city digs",
+                        "url": "#"
+                    }
+                ],
+                "subsections": [
+                    {
+                        "name": "xxx xx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xx xxxxxxxx x xxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xx xxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xx xxxxxxx",
+                        "url": "#"
+                    }
+                ]
+            },
+            {
+                "name": "xxxxxxxxx",
+                "url": "#",
+                "index": 3,
+                "hasMega": true,
+                "articles": [
+                    {
+                        "title": "The UK expats voting for Brexit no matter what the cost",
+                        "url": "#"
+                    },
+                    {
+                        "title": "Lunch with the FT: Adair Turner",
+                        "url": "#"
+                    },
+                    {
+                        "title": "English carpenter who makes beehives that sell across the world",
+                        "url": "#"
+                    },
+                    {
+                        "title": "French ambassador urges UK to help shape a ‘reformed Europe’",
+                        "url": "#"
+                    },
+                    {
+                        "title": "Where do politicians live? How MPs across the world find city digs",
+                        "url": "#"
+                    }
+                ],
+                "subsections": [
+                    {
+                        "name": "xxx xxxxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxx x xxxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxxx",
+                        "url": "#"
+                    }
+                ]
+            },
+            {
+                "name": "xxxxxxx",
+                "url": "#",
+                "index": 4,
+                "hasMega": true,
+                "articles": [
+                    {
+                        "title": "The UK expats voting for Brexit no matter what the cost",
+                        "url": "#"
+                    },
+                    {
+                        "title": "Lunch with the FT: Adair Turner",
+                        "url": "#"
+                    },
+                    {
+                        "title": "English carpenter who makes beehives that sell across the world",
+                        "url": "#"
+                    },
+                    {
+                        "title": "French ambassador urges UK to help shape a ‘reformed Europe’",
+                        "url": "#"
+                    },
+                    {
+                        "title": "Where do politicians live? How MPs across the world find city digs",
+                        "url": "#"
+                    }
+                ],
+                "subsections": [
+                    {
+                        "name": "xxx xxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxx xxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxx xxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxx",
+                        "url": "#"
+                    }
+                ]
+            },
+            {
+                "name": "xxxxxxx",
+                "url": "#",
+                "index": 5,
+                "hasMega": true,
+                "articles": [
+                    {
+                        "title": "The UK expats voting for Brexit no matter what the cost",
+                        "url": "#"
+                    },
+                    {
+                        "title": "Lunch with the FT: Adair Turner",
+                        "url": "#"
+                    },
+                    {
+                        "title": "English carpenter who makes beehives that sell across the world",
+                        "url": "#"
+                    },
+                    {
+                        "title": "French ambassador urges UK to help shape a ‘reformed Europe’",
+                        "url": "#"
+                    },
+                    {
+                        "title": "Where do politicians live? How MPs across the world find city digs",
+                        "url": "#"
+                    }
+                ],
+                "subsections": [
+                    {
+                        "name": "xxx xxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xx xxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxx xxx xxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxxxx",
+                        "url": "#"
+                    }
+                ]
+            },
+            {
+                "name": "xxxx x xxxxxxx",
+                "url": "#",
+                "index": 6,
+                "hasMega": true,
+                "articles": [
+                    {
+                        "title": "The UK expats voting for Brexit no matter what the cost",
+                        "url": "#"
+                    },
+                    {
+                        "title": "Lunch with the FT: Adair Turner",
+                        "url": "#"
+                    },
+                    {
+                        "title": "English carpenter who makes beehives that sell across the world",
+                        "url": "#"
+                    },
+                    {
+                        "title": "French ambassador urges UK to help shape a ‘reformed Europe’",
+                        "url": "#"
+                    },
+                    {
+                        "title": "Where do politicians live? How MPs across the world find city digs",
+                        "url": "#"
+                    }
+                ],
+                "subsections": [
+                    {
+                        "name": "xxx xxxx x xxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxx xxxxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxxxxxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxx xxxxx",
+                        "url": "#"
+                    }
+                ]
+            },
+            {
+                "name": "xxxx x xxxx",
+                "url": "#",
+                "index": 7,
+                "hasMega": true,
+                "articles": [
+                    {
+                        "title": "The UK expats voting for Brexit no matter what the cost",
+                        "url": "#"
+                    },
+                    {
+                        "title": "Lunch with the FT: Adair Turner",
+                        "url": "#"
+                    },
+                    {
+                        "title": "English carpenter who makes beehives that sell across the world",
+                        "url": "#"
+                    },
+                    {
+                        "title": "French ambassador urges UK to help shape a ‘reformed Europe’",
+                        "url": "#"
+                    },
+                    {
+                        "title": "Where do politicians live? How MPs across the world find city digs",
+                        "url": "#"
+                    }
+                ],
+                "subsections": [
+                    {
+                        "name": "xxx xxxx x xxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxx x xxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxx x xxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxx",
+                        "url": "#"
+                    },
+                    {
+                        "name": "xxxxx xx x xxxxx",
+                        "url": "#"
+                    }
+                ]
+            }
+        ],
+        "isSignedIn": false
+    },
+    "drawer": {
+        "nav": [
+            {
+                "heading": {
+                    "name": "xxx xxxxxxxx"
+                },
+                "items": [
+                    {
+                        "name": "xxxx",
+                        "href": "#",
+                        "selected": true,
+                        "index": 0
+                    },
+                    {
+                        "name": "xxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx xxxx xxx xxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 1
+                    },
+                    {
+                        "name": "xx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx xxxxxxxx x xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx xxxxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 2
+                    },
+                    {
+                        "name": "xxxxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx x xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 3
+                    },
+                    {
+                        "name": "xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 4
+                    },
+                    {
+                        "name": "xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxx xxx xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 5
+                    },
+                    {
+                        "name": "xxxx x xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxx xxxxxx xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx xxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx xxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 6
+                    },
+                    {
+                        "name": "xxxx x xxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxx x xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx x xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx xx x xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 7
+                    },
+                    {
+                        "name": "xxxxxxxx xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxx x xxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx x xxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 8
+                    },
+                    {
+                        "name": "xxxxxxx x xxxxxxxxxxx",
+                        "href": "#",
+                        "index": 9
+                    }
+                ]
+            },
+            {
+                "heading": {
+                    "name": "xx xxxxxxxxxx"
+                },
+                "items": [
+                    {
+                        "name": "xxx",
+                        "href": "#",
+                        "index": 0
+                    },
+                    {
+                        "name": "xxxxxxxxxx",
+                        "href": "#",
+                        "index": 1
+                    },
+                    {
+                        "name": "xxxxx xxxx xxx xx",
+                        "href": "#",
+                        "index": 2
+                    },
+                    {
+                        "name": "xxxxx",
+                        "href": "#",
+                        "index": 3
+                    },
+                    {
+                        "name": "xxxxxxx xxxxxxx",
+                        "href": "#",
+                        "index": 4
+                    },
+                    {
+                        "name": "xxxx xxxx",
+                        "href": "#",
+                        "index": 5
+                    },
+                    {
+                        "name": "xxxxxxxxxxx",
+                        "href": "#",
+                        "index": 6
+                    }
+                ]
+            },
+            {
+                "items": [
+                    {
+                        "name": "xx xx",
+                        "href": "#",
+                        "variation": "secondary",
+                        "divide": true,
+                        "index": 0
+                    },
+                    {
+                        "name": "xxxxxxxxx",
+                        "href": "#",
+                        "variation": "secondary",
+                        "index": 1
+                    },
+                    {
+                        "name": "xxxxxxx xxxxx",
+                        "href": "#",
+                        "variation": "secondary",
+                        "index": 2
+                    }
+                ]
+            }
+        ],
+        "editions": {
+            "current": {
+                "name": "xx",
+                "id": "uk"
+            },
+            "others": [
+                {
+                    "name": "xxxxxxxxxxxxx",
+                    "id": "international"
+                }
+            ]
+        },
+        "user": {
+            "isSignedIn": false,
+            "name": "xxxxxx xxxx"
+        }
+    }
 }

--- a/demos/src/subbrand.json
+++ b/demos/src/subbrand.json
@@ -1,491 +1,491 @@
 {
-	"anon": true,
-	"top": {
-		"hasMenu": true,
-		"hasMyFT": true
-	},
-	"search": true,
-	"nav": {
-		"mobile": [
-			{
-				"name": "Home",
-				"url": "#",
-				"selected": false
-			},
-			{
-				"name": "FastFT",
-				"url": "#"
-			},
-			{
-				"name": "Markets Data",
-				"url": "#"
-			}
-		],
-		"desktop": [
-			{
-				"name": "Home",
-				"url": "#",
-				"selected": false
-			},
-			{
-				"name": "World",
-				"url": "#",
-				"selected": true
-			},
-			{
-				"name": "UK",
-				"url": "#"
-			},
-			{
-				"name": "Companies",
-				"url": "#"
-			},
-			{
-				"name": "Markets",
-				"url": "#"
-			},
-			{
-				"name": "Opinion",
-				"url": "#"
-			},
-			{
-				"name": "Work & Careers",
-				"url": "#"
-			},
-			{
-				"name": "Life & Arts",
-				"url": "#"
-			}
-		],
-		"isSignedIn": false
-	},
-	"drawer": {
-		"nav": [
-			{
-				"heading": {
-					"name": "Top sections"
-				},
-				"items": [
-					{
-						"name": "Home",
-						"href": "#",
-						"selected": true,
-						"index": 0
-					},
-					{
-						"name": "World",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "World Economy",
-								"href": "#"
-							},
-							{
-								"name": "UK",
-								"href": "#"
-							},
-							{
-								"name": "US",
-								"href": "#"
-							},
-							{
-								"name": "China",
-								"href": "#"
-							},
-							{
-								"name": "Africa",
-								"href": "#"
-							},
-							{
-								"name": "Asia Pacific",
-								"href": "#"
-							},
-							{
-								"name": "Emerging Markets",
-								"href": "#"
-							},
-							{
-								"name": "Europe",
-								"href": "#"
-							},
-							{
-								"name": "Latin America",
-								"href": "#"
-							},
-							{
-								"name": "Middle East and Africa",
-								"href": "#"
-							}
-						],
-						"index": 1
-					},
-					{
-						"name": "UK",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "UK Economy",
-								"href": "#"
-							},
-							{
-								"name": "UK Politics & Policy",
-								"href": "#"
-							},
-							{
-								"name": "UK Companies",
-								"href": "#"
-							}
-						],
-						"index": 2
-					},
-					{
-						"name": "Companies",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "Energy",
-								"href": "#"
-							},
-							{
-								"name": "Financials",
-								"href": "#"
-							},
-							{
-								"name": "Health",
-								"href": "#"
-							},
-							{
-								"name": "Industrials",
-								"href": "#"
-							},
-							{
-								"name": "Media",
-								"href": "#"
-							},
-							{
-								"name": "Retail & Consumer",
-								"href": "#"
-							},
-							{
-								"name": "Technology",
-								"href": "#"
-							},
-							{
-								"name": "Telecoms",
-								"href": "#"
-							},
-							{
-								"name": "Transport",
-								"href": "#"
-							}
-						],
-						"index": 3
-					},
-					{
-						"name": "Markets",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "Alphaville",
-								"href": "#"
-							},
-							{
-								"name": "Markets Data",
-								"href": "#"
-							},
-							{
-								"name": "Capital Markets",
-								"href": "#"
-							},
-							{
-								"name": "Commodities",
-								"href": "#"
-							},
-							{
-								"name": "Currencies",
-								"href": "#"
-							},
-							{
-								"name": "Equities",
-								"href": "#"
-							},
-							{
-								"name": "Fund Management",
-								"href": "#"
-							},
-							{
-								"name": "Trading",
-								"href": "#"
-							}
-						],
-						"index": 4
-					},
-					{
-						"name": "Opinion",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "Columnists",
-								"href": "#"
-							},
-							{
-								"name": "FT View",
-								"href": "#"
-							},
-							{
-								"name": "The Big Read",
-								"href": "#"
-							},
-							{
-								"name": "Lex",
-								"href": "#"
-							},
-							{
-								"name": "Alphaville",
-								"href": "#"
-							},
-							{
-								"name": "Obituaries",
-								"href": "#"
-							},
-							{
-								"name": "Letters",
-								"href": "#"
-							}
-						],
-						"index": 5
-					},
-					{
-						"name": "Work & Careers",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "Business School Rankings",
-								"href": "#"
-							},
-							{
-								"name": "Business Education",
-								"href": "#"
-							},
-							{
-								"name": "Entrepreneurship",
-								"href": "#"
-							},
-							{
-								"name": "Recruitment",
-								"href": "#"
-							},
-							{
-								"name": "Business Books",
-								"href": "#"
-							}
-						],
-						"index": 6
-					},
-					{
-						"name": "Life & Arts",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "House & Home",
-								"href": "#"
-							},
-							{
-								"name": "Books",
-								"href": "#"
-							},
-							{
-								"name": "Food & Drink",
-								"href": "#"
-							},
-							{
-								"name": "Travel",
-								"href": "#"
-							},
-							{
-								"name": "Style",
-								"href": "#"
-							},
-							{
-								"name": "Arts",
-								"href": "#"
-							},
-							{
-								"name": "Sports",
-								"href": "#"
-							},
-							{
-								"name": "Music",
-								"href": "#"
-							},
-							{
-								"name": "Film, TV & Radio",
-								"href": "#"
-							},
-							{
-								"name": "Magazine",
-								"href": "#"
-							}
-						],
-						"index": 7
-					},
-					{
-						"name": "Personal Finance",
-						"href": "#",
-						"hasChildren": true,
-						"children": [
-							{
-								"name": "Property & Mortgages",
-								"href": "#"
-							},
-							{
-								"name": "Investments",
-								"href": "#"
-							},
-							{
-								"name": "Pensions",
-								"href": "#"
-							},
-							{
-								"name": "Tax",
-								"href": "#"
-							},
-							{
-								"name": "Bankings & Savings",
-								"href": "#"
-							}
-						],
-						"index": 8
-					},
-					{
-						"name": "Science & Environment",
-						"href": "#",
-						"index": 9
-					}
-				]
-			},
-			{
-				"heading": {
-					"name": "FT recommends"
-				},
-				"items": [
-					{
-						"name": "Lex",
-						"href": "#",
-						"index": 0
-					},
-					{
-						"name": "Alphaville",
-						"href": "#",
-						"index": 1
-					},
-					{
-						"name": "Lunch with the FT",
-						"href": "#",
-						"index": 2
-					},
-					{
-						"name": "Video",
-						"href": "#",
-						"index": 3
-					},
-					{
-						"name": "Special Reports",
-						"href": "#",
-						"index": 4
-					},
-					{
-						"name": "News feed",
-						"href": "#",
-						"index": 5
-					},
-					{
-						"name": "Newsletters",
-						"href": "#",
-						"index": 6
-					}
-				]
-			},
-			{
-				"items": [
-					{
-						"name": "My FT",
-						"href": "#",
-						"variation": "secondary",
-						"divide": true,
-						"index": 0
-					},
-					{
-						"name": "Portfolio",
-						"href": "#",
-						"variation": "secondary",
-						"index": 1
-					},
-					{
-						"name": "Today's Paper",
-						"href": "#",
-						"variation": "secondary",
-						"index": 2
-					}
-				]
-			}
-		],
-		"editions": {
-			"current": {
-				"name": "UK",
-				"id": "uk"
-			},
-			"others": [
-				{
-					"name": "International",
-					"id": "international"
-				}
-			]
-		},
-		"user": {
-			"isSignedIn": false,
-			"name": "User's name"
-		}
-	},
-	"subnav": true,
-	"currentNav": {
-		"name": "Life & Arts",
-		"children": [
-			{
-				"name": "House & Home",
-				"href": "#"
-			},
-			{
-				"name": "Books",
-				"href": "#"
-			},
-			{
-				"name": "Food & Drink",
-				"href": "#"
-			},
-			{
-				"name": "Travel",
-				"href": "#"
-			},
-			{
-				"name": "Style",
-				"href": "#"
-			},
-			{
-				"name": "Arts",
-				"href": "#"
-			},
-			{
-				"name": "FT Magazine",
-				"href": "#"
-			}
-		]
-	}
+    "anon": true,
+    "top": {
+        "hasMenu": true,
+        "hasMyFT": true
+    },
+    "search": true,
+    "nav": {
+        "mobile": [
+            {
+                "name": "xxxx",
+                "url": "#",
+                "selected": false
+            },
+            {
+                "name": "xxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxxxxx xxxx",
+                "url": "#"
+            }
+        ],
+        "desktop": [
+            {
+                "name": "xxxx",
+                "url": "#",
+                "selected": false
+            },
+            {
+                "name": "xxxxx",
+                "url": "#",
+                "selected": true
+            },
+            {
+                "name": "xx",
+                "url": "#"
+            },
+            {
+                "name": "xxxxxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxx x xxxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxx x xxxx",
+                "url": "#"
+            }
+        ],
+        "isSignedIn": false
+    },
+    "drawer": {
+        "nav": [
+            {
+                "heading": {
+                    "name": "xxx xxxxxxxx"
+                },
+                "items": [
+                    {
+                        "name": "xxxx",
+                        "href": "#",
+                        "selected": true,
+                        "index": 0
+                    },
+                    {
+                        "name": "xxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx xxxx xxx xxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 1
+                    },
+                    {
+                        "name": "xx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx xxxxxxxx x xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx xxxxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 2
+                    },
+                    {
+                        "name": "xxxxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx x xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 3
+                    },
+                    {
+                        "name": "xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 4
+                    },
+                    {
+                        "name": "xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxx xxx xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 5
+                    },
+                    {
+                        "name": "xxxx x xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxx xxxxxx xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx xxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx xxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 6
+                    },
+                    {
+                        "name": "xxxx x xxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxx x xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx x xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx xx x xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 7
+                    },
+                    {
+                        "name": "xxxxxxxx xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxx x xxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx x xxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 8
+                    },
+                    {
+                        "name": "xxxxxxx x xxxxxxxxxxx",
+                        "href": "#",
+                        "index": 9
+                    }
+                ]
+            },
+            {
+                "heading": {
+                    "name": "xx xxxxxxxxxx"
+                },
+                "items": [
+                    {
+                        "name": "xxx",
+                        "href": "#",
+                        "index": 0
+                    },
+                    {
+                        "name": "xxxxxxxxxx",
+                        "href": "#",
+                        "index": 1
+                    },
+                    {
+                        "name": "xxxxx xxxx xxx xx",
+                        "href": "#",
+                        "index": 2
+                    },
+                    {
+                        "name": "xxxxx",
+                        "href": "#",
+                        "index": 3
+                    },
+                    {
+                        "name": "xxxxxxx xxxxxxx",
+                        "href": "#",
+                        "index": 4
+                    },
+                    {
+                        "name": "xxxx xxxx",
+                        "href": "#",
+                        "index": 5
+                    },
+                    {
+                        "name": "xxxxxxxxxxx",
+                        "href": "#",
+                        "index": 6
+                    }
+                ]
+            },
+            {
+                "items": [
+                    {
+                        "name": "xx xx",
+                        "href": "#",
+                        "variation": "secondary",
+                        "divide": true,
+                        "index": 0
+                    },
+                    {
+                        "name": "xxxxxxxxx",
+                        "href": "#",
+                        "variation": "secondary",
+                        "index": 1
+                    },
+                    {
+                        "name": "xxxxxxx xxxxx",
+                        "href": "#",
+                        "variation": "secondary",
+                        "index": 2
+                    }
+                ]
+            }
+        ],
+        "editions": {
+            "current": {
+                "name": "xx",
+                "id": "uk"
+            },
+            "others": [
+                {
+                    "name": "xxxxxxxxxxxxx",
+                    "id": "international"
+                }
+            ]
+        },
+        "user": {
+            "isSignedIn": false,
+            "name": "xxxxxx xxxx"
+        }
+    },
+    "subnav": true,
+    "currentNav": {
+        "name": "xxxx x xxxx",
+        "children": [
+            {
+                "name": "xxxxx x xxxx",
+                "href": "#"
+            },
+            {
+                "name": "xxxxx",
+                "href": "#"
+            },
+            {
+                "name": "xxxx x xxxxx",
+                "href": "#"
+            },
+            {
+                "name": "xxxxxx",
+                "href": "#"
+            },
+            {
+                "name": "xxxxx",
+                "href": "#"
+            },
+            {
+                "name": "xxxx",
+                "href": "#"
+            },
+            {
+                "name": "xx xxxxxxxx",
+                "href": "#"
+            }
+        ]
+    }
 }

--- a/demos/src/subnav.json
+++ b/demos/src/subnav.json
@@ -8,63 +8,63 @@
 	"nav": {
 		"mobile": [
 			{
-				"name": "Home",
+				"name": "xxxx",
 				"url": "#",
 				"selected": false
 			},
 			{
-				"name": "FastFT",
+				"name": "xxxxxx",
 				"url": "#"
 			},
 			{
-				"name": "Markets Data",
+				"name": "xxxxxxx xxxx",
 				"url": "#"
 			}
 		],
 		"desktop": [
 			{
-				"name": "Home",
+				"name": "xxxx",
 				"url": "#",
 				"selected": true
 			},
 			{
-				"name": "World",
+				"name": "xxxxx",
 				"url": "#"
 			},
 			{
-				"name": "UK",
+				"name": "xx",
 				"url": "#"
 			},
 			{
-				"name": "Companies",
+				"name": "xxxxxxxxx",
 				"url": "#"
 			},
 			{
-				"name": "Tech",
+				"name": "xxxx",
 				"url": "#"
 			},
 			{
-				"name": "Markets",
+				"name": "xxxxxxx",
 				"url": "#"
 			},
 			{
-				"name": "Opinion",
+				"name": "xxxxxxx",
 				"url": "#"
 			},
 			{
-				"name": "Work & Careers",
+				"name": "xxxx x xxxxxxx",
 				"url": "#"
 			},
 			{
-				"name": "Life & Arts",
+				"name": "xxxx x xxxx",
 				"url": "#"
 			},
 			{
-				"name": "Graphics",
+				"name": "xxxxxxxx",
 				"url": "#"
 			},
 			{
-				"name": "How to spend it",
+				"name": "xxx xx xxxxx xx",
 				"url": "#"
 			}
 		],
@@ -74,309 +74,309 @@
 		"nav": [
 			{
 				"heading": {
-					"name": "Top sections"
+					"name": "xxx xxxxxxxx"
 				},
 				"items": [
 					{
-						"name": "Home",
+						"name": "xxxx",
 						"href": "#",
 						"selected": true,
 						"index": 0
 					},
 					{
-						"name": "World",
+						"name": "xxxxx",
 						"href": "#",
 						"hasChildren": true,
 						"children": [
 							{
-								"name": "World Economy",
+								"name": "xxxxx xxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "UK",
+								"name": "xx",
 								"href": "#"
 							},
 							{
-								"name": "US",
+								"name": "xx",
 								"href": "#"
 							},
 							{
-								"name": "China",
+								"name": "xxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Africa",
+								"name": "xxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Asia Pacific",
+								"name": "xxxx xxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Emerging Markets",
+								"name": "xxxxxxxx xxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Europe",
+								"name": "xxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Latin America",
+								"name": "xxxxx xxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Middle East and Africa",
+								"name": "xxxxxx xxxx xxx xxxxxx",
 								"href": "#"
 							}
 						],
 						"index": 1
 					},
 					{
-						"name": "UK",
+						"name": "xx",
 						"href": "#",
 						"hasChildren": true,
 						"children": [
 							{
-								"name": "UK Economy",
+								"name": "xx xxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "UK Politics & Policy",
+								"name": "xx xxxxxxxx x xxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "UK Companies",
+								"name": "xx xxxxxxxxx",
 								"href": "#"
 							}
 						],
 						"index": 2
 					},
 					{
-						"name": "Companies",
+						"name": "xxxxxxxxx",
 						"href": "#",
 						"hasChildren": true,
 						"children": [
 							{
-								"name": "Energy",
+								"name": "xxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Financials",
+								"name": "xxxxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Health",
+								"name": "xxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Industrials",
+								"name": "xxxxxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Media",
+								"name": "xxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Retail & Consumer",
+								"name": "xxxxxx x xxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Technology",
+								"name": "xxxxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Telecoms",
+								"name": "xxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Transport",
+								"name": "xxxxxxxxx",
 								"href": "#"
 							}
 						],
 						"index": 3
 					},
 					{
-						"name": "Markets",
+						"name": "xxxxxxx",
 						"href": "#",
 						"hasChildren": true,
 						"children": [
 							{
-								"name": "Alphaville",
+								"name": "xxxxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Markets Data",
+								"name": "xxxxxxx xxxx",
 								"href": "#"
 							},
 							{
-								"name": "Capital Markets",
+								"name": "xxxxxxx xxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Commodities",
+								"name": "xxxxxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Currencies",
+								"name": "xxxxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Equities",
+								"name": "xxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Fund Management",
+								"name": "xxxx xxxxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Trading",
+								"name": "xxxxxxx",
 								"href": "#"
 							}
 						],
 						"index": 4
 					},
 					{
-						"name": "Opinion",
+						"name": "xxxxxxx",
 						"href": "#",
 						"hasChildren": true,
 						"children": [
 							{
-								"name": "Columnists",
+								"name": "xxxxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "FT View",
+								"name": "xx xxxx",
 								"href": "#"
 							},
 							{
-								"name": "The Big Read",
+								"name": "xxx xxx xxxx",
 								"href": "#"
 							},
 							{
-								"name": "Lex",
+								"name": "xxx",
 								"href": "#"
 							},
 							{
-								"name": "Alphaville",
+								"name": "xxxxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Obituaries",
+								"name": "xxxxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Letters",
+								"name": "xxxxxxx",
 								"href": "#"
 							}
 						],
 						"index": 5
 					},
 					{
-						"name": "Work & Careers",
+						"name": "xxxx x xxxxxxx",
 						"href": "#",
 						"hasChildren": true,
 						"children": [
 							{
-								"name": "Business School Rankings",
+								"name": "xxxxxxxx xxxxxx xxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Business Education",
+								"name": "xxxxxxxx xxxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Entrepreneurship",
+								"name": "xxxxxxxxxxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Recruitment",
+								"name": "xxxxxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Business Books",
+								"name": "xxxxxxxx xxxxx",
 								"href": "#"
 							}
 						],
 						"index": 6
 					},
 					{
-						"name": "Life & Arts",
+						"name": "xxxx x xxxx",
 						"href": "#",
 						"hasChildren": true,
 						"children": [
 							{
-								"name": "House & Home",
+								"name": "xxxxx x xxxx",
 								"href": "#"
 							},
 							{
-								"name": "Books",
+								"name": "xxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Food & Drink",
+								"name": "xxxx x xxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Travel",
+								"name": "xxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Style",
+								"name": "xxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Arts",
+								"name": "xxxx",
 								"href": "#"
 							},
 							{
-								"name": "Sports",
+								"name": "xxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Music",
+								"name": "xxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Film, TV & Radio",
+								"name": "xxxxx xx x xxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Magazine",
+								"name": "xxxxxxxx",
 								"href": "#"
 							}
 						],
 						"index": 7
 					},
 					{
-						"name": "Personal Finance",
+						"name": "xxxxxxxx xxxxxxx",
 						"href": "#",
 						"hasChildren": true,
 						"children": [
 							{
-								"name": "Property & Mortgages",
+								"name": "xxxxxxxx x xxxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Investments",
+								"name": "xxxxxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Pensions",
+								"name": "xxxxxxxx",
 								"href": "#"
 							},
 							{
-								"name": "Tax",
+								"name": "xxx",
 								"href": "#"
 							},
 							{
-								"name": "Bankings & Savings",
+								"name": "xxxxxxxx x xxxxxxx",
 								"href": "#"
 							}
 						],
 						"index": 8
 					},
 					{
-						"name": "Science & Environment",
+						"name": "xxxxxxx x xxxxxxxxxxx",
 						"href": "#",
 						"index": 9
 					}
@@ -384,41 +384,41 @@
 			},
 			{
 				"heading": {
-					"name": "FT recommends"
+					"name": "xx xxxxxxxxxx"
 				},
 				"items": [
 					{
-						"name": "Lex",
+						"name": "xxx",
 						"href": "#",
 						"index": 0
 					},
 					{
-						"name": "Alphaville",
+						"name": "xxxxxxxxxx",
 						"href": "#",
 						"index": 1
 					},
 					{
-						"name": "Lunch with the FT",
+						"name": "xxxxx xxxx xxx xx",
 						"href": "#",
 						"index": 2
 					},
 					{
-						"name": "Video",
+						"name": "xxxxx",
 						"href": "#",
 						"index": 3
 					},
 					{
-						"name": "Special Reports",
+						"name": "xxxxxxx xxxxxxx",
 						"href": "#",
 						"index": 4
 					},
 					{
-						"name": "News feed",
+						"name": "xxxx xxxx",
 						"href": "#",
 						"index": 5
 					},
 					{
-						"name": "Newsletters",
+						"name": "xxxxxxxxxxx",
 						"href": "#",
 						"index": 6
 					}
@@ -427,20 +427,20 @@
 			{
 				"items": [
 					{
-						"name": "My FT",
+						"name": "xx xx",
 						"href": "#",
 						"variation": "secondary",
 						"divide": true,
 						"index": 0
 					},
 					{
-						"name": "Portfolio",
+						"name": "xxxxxxxxx",
 						"href": "#",
 						"variation": "secondary",
 						"index": 1
 					},
 					{
-						"name": "Today's Paper",
+						"name": "xxxxxxx xxxxx",
 						"href": "#",
 						"variation": "secondary",
 						"index": 2
@@ -450,42 +450,42 @@
 		],
 		"editions": {
 			"current": {
-				"name": "UK",
+				"name": "xx",
 				"id": "uk"
 			},
 			"others": [
 				{
-					"name": "International",
+					"name": "xxxxxxxxxxxxx",
 					"id": "international"
 				}
 			]
 		},
 		"user": {
 			"isSignedIn": false,
-			"name": "User's name"
+			"name": "xxxxxx xxxx"
 		}
 	},
 	"subnav": true,
 	"currentNav": {
-		"name": "US & Canada",
+		"name": "xx x xxxxxx",
 		"selected": true,
 		"ancestors": [
 			{
-				"name": "World",
+				"name": "xxxxx",
 				"href": "#"
 			}
 		],
 		"children": [
 			{
-				"name": "US Economy",
+				"name": "xx xxxxxxx",
 				"href": "#"
 			},
 			{
-				"name": "US Politics & Policy",
+				"name": "xx xxxxxxxx x xxxxxx",
 				"href": "#"
 			},
 			{
-				"name": "US Companies",
+				"name": "xx xxxxxxxxx",
 				"href": "#"
 			}
 		]

--- a/origami.json
+++ b/origami.json
@@ -44,35 +44,35 @@
 			"title": "Header",
 			"data": "demos/src/header.json",
 			"template": "demos/src/header.mustache",
-			"description": ""
+			"description": "Use the Origami Navigation Service to populate o-header with real navigation data. See the readme for more details."
 		},
 		{
 			"name": "mega-menu",
 			"title": "Mega menu",
 			"data": "demos/src/mega-menu.json",
 			"template": "demos/src/mega-menu.mustache",
-			"description": ""
+			"description": "Use the Origami Navigation Service to populate o-header with real navigation data. See the readme for more details."
 		},
 		{
 			"name": "subnav",
 			"title": "Header with subnav",
 			"data": "demos/src/subnav.json",
 			"template": "demos/src/subnav.mustache",
-			"description": ""
+			"description": "Use the Origami Navigation Service to populate o-header with real navigation data. See the readme for more details."
 		},
 		{
 			"name": "simple-header",
 			"title": "Simple header",
 			"data": "demos/src/header.json",
 			"template": "demos/src/simple-header.mustache",
-			"description": ""
+			"description": "Use the Origami Navigation Service to populate o-header with real navigation data. See the readme for more details."
 		},
 		{
 			"name": "transparent-header",
 			"title": "Transparent header",
 			"data": "demos/src/header.json",
 			"template": "demos/src/transparent-header.mustache",
-			"description": "",
+			"description": "Use the Origami Navigation Service to populate o-header with real navigation data. See the readme for more details.",
 			"documentClasses": "demo-transparent"
 		},
 		{
@@ -80,7 +80,7 @@
 			"title": "Sticky header",
 			"data": "demos/src/header.json",
 			"template": "demos/src/sticky-header.mustache",
-			"description": "Sticky variation of the simple header",
+			"description": "Sticky variation of the simple header. Use the Origami Navigation Service to populate o-header with real navigation data. See the readme for more details.",
 			"documentClasses": "demo-sticky"
 		},
 		{
@@ -88,7 +88,7 @@
 			"title": "Subbranded header",
 			"data": "demos/src/subbrand.json",
 			"template": "demos/src/subbrand.mustache",
-			"description": "For Subbrands of the FT, eg Alphaville or Life&Arts, a subheader can be added to mark out their subbrandness."
+			"description": "For Subbrands of the FT, eg Alphaville or Life&Arts, a subheader can be added to mark out their subbrandness. Use the Origami Navigation Service to populate o-header with real navigation data. See the readme for more details."
 		},
 		{
 			"name": "grid-demo",


### PR DESCRIPTION
Users copy and paste from o-header demos and use out of date
navigation within their project. We considered populating
o-header demos using Origami Navigation Service data but do
not want users to copy/paste static navigation which will not
update.

Fixes: https://github.com/Financial-Times/o-header/issues/160
Relates to: https://github.com/Financial-Times/origami-build-tools/pull/718