### PR TITLE
Remove Internet Explorer auto-hiding scrollbar.

### DIFF
--- a/src/scss/features/_drawer.scss
+++ b/src/scss/features/_drawer.scss
@@ -60,10 +60,6 @@
 			// sass-lint:enable no-vendor-prefixes
 			// working draft
 			scroll-behavior: smooth;
-			// Windows 8+
-			// sass-lint:disable no-vendor-prefixes
-			-ms-overflow-style: -ms-autohiding-scrollbar;
-			// sass-lint:enable no-vendor-prefixes
 
 			// sass-lint:disable no-misspelled-properties
 			scrollbar-color: oColorsByName('black-30') transparent;


### PR DESCRIPTION
When `-ms-overflow-style: -ms-autohiding-scrollbar;` is set
Internet Explorer hides the scrollbar until it is scrolled. After
scrolling the sidebar remains visible and partially obscures active
elements.

The scrollbar is always visible in IE now and obscures no active elements
<img width="606" alt="Screenshot 2020-03-30 at 15 29 38" src="https://user-images.githubusercontent.com/10405691/77924184-4a48be00-729b-11ea-803a-59412ebfde5d.png">


https://github.com/Financial-Times/o-header/issues/365