### PR TITLE
Remove Internet Explorer auto-hiding scrollbar.

### DIFF
--- a/src/scss/features/_drawer.scss
+++ b/src/scss/features/_drawer.scss
@@ -59,10 +59,6 @@
 			// sass-lint:enable no-vendor-prefixes
 			// working draft
 			scroll-behavior: smooth;
-			// Windows 8+
-			// sass-lint:disable no-vendor-prefixes
-			-ms-overflow-style: -ms-autohiding-scrollbar;
-			// sass-lint:enable no-vendor-prefixes
 
 			// sass-lint:disable no-misspelled-properties
 			scrollbar-color: oColorsGetPaletteColor('black-30') transparent;


### PR DESCRIPTION
Backported from o-header v8.

When `-ms-overflow-style: -ms-autohiding-scrollbar;` is set
Internet Explorer hides the scrollbar until it is scrolled. After
scrolling the sidebar remains visible and partially obscures active
elements.

https://github.com/Financial-Times/o-header/issues/365