### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -18,7 +18,7 @@ $_o-header-subnav-height-medium: 36px;
 $_o-header-item-separator-percentage-height: 0.7;
 $_o-header-sub-header-focus-margin: 5px;
 
-/* at some point these should be normalised in o-icons */
+// at some point these should be normalised in o-icons
 $_o-header-icon-size-large: 40;
 $_o-header-icon-size: 25;
 $_o-header-icon-size-small: 15;

--- a/test/autoinitialisation.test.js
+++ b/test/autoinitialisation.test.js
@@ -1,8 +1,7 @@
 /* eslint-env mocha */
+/* global proclaim sinon */
 
 import fixtures from './helpers/fixtures';
-import sinon from 'sinon/pkg/sinon';
-import proclaim from 'proclaim';
 import Header from '../main.js';
 
 let pcfEl;

--- a/test/drawer.test.js
+++ b/test/drawer.test.js
@@ -1,7 +1,6 @@
 /* eslint-env mocha */
+/* global proclaim sinon */
 
-import sinon from 'sinon/pkg/sinon';
-import proclaim from 'proclaim';
 import Drawer from '../src/js/drawer';
 
 describe('Drawer instance', () => {

--- a/test/header.test.js
+++ b/test/header.test.js
@@ -1,6 +1,6 @@
-/* eslint-env mocha*/
+/* eslint-env mocha */
+/* global proclaim */
 
-import proclaim from 'proclaim';
 import Header from '../src/js/header';
 
 describe('Header API', () => {

--- a/test/mega.test.js
+++ b/test/mega.test.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
+/* global proclaim */
 
-import proclaim from 'proclaim';
 import mega from '../src/js/mega';
 
 function dispatch (target, type) {


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.