### PR TITLE
NOPSCOPS-254: Hide header nav on small screens

### DIFF
--- a/src/scss/features/_nav.scss
+++ b/src/scss/features/_nav.scss
@@ -3,6 +3,14 @@
 		@include oTypographySans($scale: -1, $line-height: 20px);
 	}
 
+	.o-header__nav--hide-s {
+		display: none;
+
+		@include oGridRespondTo('S') {
+			display: block;
+		}
+	}
+
 	.o-header__nav--mobile {
 		white-space: nowrap;
 


### PR DESCRIPTION
OpsCops ticket: https://financialtimes.atlassian.net/browse/NOPSCOPS-254

<img width="351" alt="incorrect_buttons_aligned_with_masthead" src="https://user-images.githubusercontent.com/21983479/78786729-28d58980-79a1-11ea-9dfb-41f91c828c98.png">

The navigation is inline with the masthead. On small screens the elements move into each other.

This PR hides the navigation element on small screens.

TODO:
- [ ] test the change
- [ ] confirm this behaviour with UI/UX