### PR TITLE
NOPSCOPS-254: Add option to hide nav items at small screen width

### DIFF
--- a/src/scss/features/_nav.scss
+++ b/src/scss/features/_nav.scss
@@ -60,6 +60,14 @@
 		}
 	}
 
+	.o-header__nav-item--hide-s {
+		display: none;
+
+		@include oGridRespondTo('S') {
+			display: table-cell;
+		}
+	}
+
 	.o-header__nav-item--expanded {
 		@include oGridRespondTo($until: 'M') {
 			display: none;


### PR DESCRIPTION
Very similar to https://github.com/Financial-Times/o-header/pull/372 but this change gives the option to hide individual nav elements.