### PR TITLE
Ensure header link buttons work when pressing space.

### DIFF
--- a/src/js/header.js
+++ b/src/js/header.js
@@ -4,6 +4,24 @@ import drawer from './drawer';
 import subnav from './subnav';
 import sticky from './sticky';
 
+// Some assistive technologies, like screen readers, suggest to press 'space'
+// when interacting with a link with a role of 'button'.
+// We need to ensure that we replicate this functionality that exists on a button element.
+// In the future we should consider using the 'button' element instead.
+function handleSpaceKeydown (e) {
+	// get the target element
+	const target = e.target
+	const targetIsRoleButton = target.getAttribute('role') === 'button'
+	// if the pressed key is a space, we'll simulate a click
+	const keyPressIsSpace = e.keyCode === 32
+	if (targetIsRoleButton && keyPressIsSpace) {
+		// prevent space from scrolling the page
+		e.preventDefault();
+		// trigger the target's click event
+		target.click();
+	}
+}
+
 class Header {
 
 	constructor (headerEl) {
@@ -24,6 +42,8 @@ class Header {
 		drawer.init(this.headerEl);
 		subnav.init(this.headerEl);
 		sticky.init(this.headerEl);
+
+		headerEl.addEventListener('keydown', handleSpaceKeydown);
 
 		this.headerEl.removeAttribute('data-o-header--no-js');
 		this.headerEl.setAttribute('data-o-header--js', '');

--- a/src/js/header.js
+++ b/src/js/header.js
@@ -10,10 +10,10 @@ import sticky from './sticky';
 // In the future we should consider using the 'button' element instead.
 function handleSpaceKeydown (e) {
 	// get the target element
-	const target = e.target
-	const targetIsRoleButton = target.getAttribute('role') === 'button'
+	const target = e.target;
+	const targetIsRoleButton = target.getAttribute('role') === 'button';
 	// if the pressed key is a space, we'll simulate a click
-	const keyPressIsSpace = e.keyCode === 32
+	const keyPressIsSpace = e.keyCode === 32;
 	if (targetIsRoleButton && keyPressIsSpace) {
 		// prevent space from scrolling the page
 		e.preventDefault();

--- a/test/header.test.js
+++ b/test/header.test.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim */
 
+import { dispatch } from './helpers/events';
 import Header from '../src/js/header';
 
 describe('Header API', () => {
@@ -10,6 +11,7 @@ describe('Header API', () => {
 });
 
 describe('Header instance', () => {
+	let header;
 	let headerEl;
 	let containerEl;
 
@@ -17,21 +19,55 @@ describe('Header instance', () => {
 		containerEl = document.createElement('div');
 		document.body.appendChild(containerEl);
 		containerEl.innerHTML = `
-			<header class="o-header" data-o-component="o-header"></header>
+			<header class="o-header" data-o-component="o-header" data-o-header--no-js>
+				<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" title="Open drawer menu">
+					<span class="o-header__top-link-label">Open drawer menu</span>
+				</a>
+				<a href="#o-header-search" class="o-header__top-link o-header__top-link--search" aria-controls="o-header-search-js" title="Open search bar">
+					<span class="o-header__top-link-label">Open search bar</span>
+				</a>
+				<div id="o-header-search-js" class="o-header__row o-header__search" role="search" data-o-header-search>
+					<input class="o-header__search-term" id="o-header-search-term-js" name="q" type="text" placeholder="Search the FT">
+				</div>
+			</header>
+			<div class="o-header__drawer" id="o-header-drawer" role="navigation" aria-label="Drawer menu" data-o-header-drawer data-o-header-drawer--no-js></div>
 		`;
 		headerEl = containerEl.querySelector('.o-header');
+		header = new Header(headerEl);
 	});
 
 	afterEach(() => {
 		containerEl.removeChild(headerEl);
+		header = null;
 		headerEl = null;
 		containerEl = null;
 	});
 
 	it('constructor', () => {
-		const header = new Header(headerEl);
 		proclaim.isInstanceOf(header, Header);
 		proclaim.deepEqual(header.headerEl, headerEl);
 		proclaim.isNotNull(headerEl.getAttribute('data-o-header--js'));
+	});
+
+	it('shows the menu when activating menu button by pressing space', () => {
+		const menuButton = document.querySelector('[aria-controls="o-header-drawer"]');
+		const drawer = document.getElementById('o-header-drawer');
+
+		proclaim.equal(drawer.getAttribute('aria-hidden'), 'true');
+
+		dispatch(menuButton, 'keydown', { keyCode: 32 });
+
+		proclaim.equal(drawer.getAttribute('aria-hidden'), 'false');
+	});
+
+	it('shows the search when activating search button by pressing space', () => {
+		const searchButton = document.querySelector('[aria-controls="o-header-search-js"]');
+		const search = document.getElementById('o-header-search-js');
+
+		proclaim.equal(search.getAttribute('aria-hidden'), 'true');
+
+		dispatch(searchButton, 'keydown', { keyCode: 32 });
+
+		proclaim.equal(search.getAttribute('aria-hidden'), 'false');
 	});
 });

--- a/test/helpers/events.js
+++ b/test/helpers/events.js
@@ -1,8 +1,10 @@
 export function dispatch (target, type, eventProperties) {
 	const event = new Event(type, { bubbles: true });
 	for (const property in eventProperties) {
-		event[property] = eventProperties[property];
-	} 
+		if (eventProperties.hasOwnProperty(property)) {
+			event[property] = eventProperties[property];
+		}
+	}
 	target.dispatchEvent(event);
 }
 

--- a/test/helpers/events.js
+++ b/test/helpers/events.js
@@ -1,0 +1,15 @@
+export function dispatch (target, type, eventProperties) {
+	const event = new Event(type, { bubbles: true });
+	for (const property in eventProperties) {
+		event[property] = eventProperties[property];
+	} 
+	target.dispatchEvent(event);
+}
+
+export function waitFor (target, events) {
+	const promises = events.map(event => {
+		return new Promise(resolve => target.addEventListener(event, resolve));
+	});
+
+	return Promise.all(promises);
+}

--- a/test/mega.test.js
+++ b/test/mega.test.js
@@ -1,19 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim */
 
+import { dispatch, waitFor } from './helpers/events';
 import mega from '../src/js/mega';
-
-function dispatch (target, type) {
-	target.dispatchEvent(new Event(type, { bubbles: true }));
-}
-
-function waitFor (target, events) {
-	const promises = events.map(event => {
-		return new Promise(resolve => target.addEventListener(event, resolve));
-	});
-
-	return Promise.all(promises);
-}
 
 describe('Mega', () => {
 	let containerEl;


### PR DESCRIPTION
Some assistive technologies, like screen readers, suggest to press 'space' when interacting with a link with a role of 'button'.
We need to ensure that we replicate this functionality that exists on a button element.
In the future we should consider using the 'button' element instead.

I decided against changing the link to a button to avoid a breaking change, and @notlee has let me know that the anchor is used in the 'core' experience to link to the bottom of the page.

I'm wondering if it's better to put this space handling next to the calls to `Toggle`, but went with this top level handler so there's only one event listener... Welcome your thoughts there.

Closes https://github.com/Financial-Times/o-header/issues/380