### PR TITLE
Update drawer menu accessible name for plain english alternative

### DIFF
--- a/demos/src/grid-demo.mustache
+++ b/demos/src/grid-demo.mustache
@@ -19,8 +19,8 @@
 			<div class="o-header__top-wrapper">
 				<div class="o-header__top-column o-header__top-column--left">
 					{{#hasMenu}}
-					<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" title="Open drawer menu">
-						<span class="o-header__top-link-label">Open drawer menu</span>
+					<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" title="Open side navigation menu">
+						<span class="o-header__top-link-label">Open side navigation menu</span>
 					</a>
 					{{/hasMenu}}
 					<a href="#o-header-search" class="o-header__top-link o-header__top-link--search" aria-controls="o-header-search-js" title="Open search bar">

--- a/demos/src/header.mustache
+++ b/demos/src/header.mustache
@@ -19,8 +19,8 @@
 			<div class="o-header__top-wrapper">
 				<div class="o-header__top-column o-header__top-column--left">
 					{{#hasMenu}}
-					<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" title="Open drawer menu">
-						<span class="o-header__top-link-label">Open drawer menu</span>
+					<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" title="Open side navigation menu">
+						<span class="o-header__top-link-label">Open side navigation menu</span>
 					</a>
 					{{/hasMenu}}
 					<a href="#o-header-search" class="o-header__top-link o-header__top-link--search" aria-controls="o-header-search-js" title="Open search bar">

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -19,8 +19,8 @@
 			<div class="o-header__top-wrapper">
 				<div class="o-header__top-column o-header__top-column--left">
 					{{#hasMenu}}
-					<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" title="Open drawer menu">
-						<span class="o-header__top-link-label">Open drawer menu</span>
+					<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" title="Open side navigation menu">
+						<span class="o-header__top-link-label">Open side navigation menu</span>
 					</a>
 					{{/hasMenu}}
 					<a href="#o-header-search" class="o-header__top-link o-header__top-link--search" aria-controls="o-header-search-js" title="Open search bar">

--- a/demos/src/simple-header.mustache
+++ b/demos/src/simple-header.mustache
@@ -5,8 +5,8 @@
 
 				<div class="o-header__top-column o-header__top-column--left">
 					{{#top.hasMenu}}
-					<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" title="Open drawer menu">
-						<span class="o-header__top-link-label">Open drawer menu</span>
+					<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" title="Open side navigation menu">
+						<span class="o-header__top-link-label">Open side navigation menu</span>
 					</a>
 					{{/top.hasMenu}}
 					<a href="#o-header-search" class="o-header__top-link o-header__top-link--search" aria-controls="o-header-search" title="Open search bar">

--- a/demos/src/sticky-header.mustache
+++ b/demos/src/sticky-header.mustache
@@ -6,7 +6,7 @@
 				<div class="o-header__top-column o-header__top-column--left">
 					{{#top.hasMenu}}
 					<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" tabindex="-1">
-						<span class="o-header__top-link-label">Open drawer menu</span>
+						<span class="o-header__top-link-label">Open side navigation menu</span>
 					</a>
 					{{/top.hasMenu}}
 					<a href="#o-header-search-sticky" class="o-header__top-link o-header__top-link--search" aria-controls="o-header-search-sticky" tabindex="-1">

--- a/demos/src/subbrand.mustache
+++ b/demos/src/subbrand.mustache
@@ -5,8 +5,8 @@
 
 				<div class="o-header__top-column o-header__top-column--left">
 					{{#top.hasMenu}}
-					<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" title="Open drawer menu">
-						<span class="o-header__top-link-label">Open drawer menu</span>
+					<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" title="Open side navigation menu">
+						<span class="o-header__top-link-label">Open side navigation menu</span>
 					</a>
 					{{/top.hasMenu}}
 					<a href="#o-header-search" class="o-header__top-link o-header__top-link--search" aria-controls="o-header-search" title="Open search bar">

--- a/demos/src/transparent-header.mustache
+++ b/demos/src/transparent-header.mustache
@@ -5,8 +5,8 @@
 
 				<div class="o-header__top-column o-header__top-column--left">
 					{{#top.hasMenu}}
-					<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" title="Open drawer menu">
-						<span class="o-header__top-link-label">Open drawer menu</span>
+					<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" title="Open side navigation menu">
+						<span class="o-header__top-link-label">Open side navigation menu</span>
 					</a>
 					{{/top.hasMenu}}
 					<a href="#o-header-search" class="o-header__top-link o-header__top-link--search" aria-controls="o-header-search" title="Open search bar">


### PR DESCRIPTION
Drawer is an internal description, so 'side navigation' is more common place
so is more likely to be understood by people.

I will also open a pull request that reflects this change downstream in Page kit.

This was recommended by the Digital Accessibility Center (DAC) audit

DAC ID: IDAC_Non-Descriptive_Form_Elements_Issue1

Jira ticket: CPP-113