### PR TITLE
Add support for right aligned subnav items.

### DIFF
--- a/demos/src/subnav-right-align.json
+++ b/demos/src/subnav-right-align.json
@@ -1,0 +1,499 @@
+{
+    "anon": true,
+    "top": {
+        "hasMenu": true,
+        "hasMyFT": true
+    },
+    "search": true,
+    "nav": {
+        "mobile": [
+            {
+                "name": "xxxx",
+                "url": "#",
+                "selected": false
+            },
+            {
+                "name": "xxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxxxxx xxxx",
+                "url": "#"
+            }
+        ],
+        "desktop": [
+            {
+                "name": "xxxx",
+                "url": "#",
+                "selected": true
+            },
+            {
+                "name": "xxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xx",
+                "url": "#"
+            },
+            {
+                "name": "xxxxxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxx x xxxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxx x xxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxxxxxxx",
+                "url": "#"
+            },
+            {
+                "name": "xxx xx xxxxx xx",
+                "url": "#"
+            }
+        ],
+        "isSignedIn": true
+    },
+    "drawer": {
+        "nav": [
+            {
+                "heading": {
+                    "name": "xxx xxxxxxxx"
+                },
+                "items": [
+                    {
+                        "name": "xxxx",
+                        "href": "#",
+                        "selected": true,
+                        "index": 0
+                    },
+                    {
+                        "name": "xxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx xxxx xxx xxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 1
+                    },
+                    {
+                        "name": "xx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx xxxxxxxx x xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx xxxxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 2
+                    },
+                    {
+                        "name": "xxxxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx x xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 3
+                    },
+                    {
+                        "name": "xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx xxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 4
+                    },
+                    {
+                        "name": "xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xx xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxx xxx xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 5
+                    },
+                    {
+                        "name": "xxxx x xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxx xxxxxx xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx xxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx xxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 6
+                    },
+                    {
+                        "name": "xxxx x xxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxx x xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx x xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxx xx x xxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 7
+                    },
+                    {
+                        "name": "xxxxxxxx xxxxxxx",
+                        "href": "#",
+                        "hasChildren": true,
+                        "children": [
+                            {
+                                "name": "xxxxxxxx x xxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxx",
+                                "href": "#"
+                            },
+                            {
+                                "name": "xxxxxxxx x xxxxxxx",
+                                "href": "#"
+                            }
+                        ],
+                        "index": 8
+                    },
+                    {
+                        "name": "xxxxxxx x xxxxxxxxxxx",
+                        "href": "#",
+                        "index": 9
+                    }
+                ]
+            },
+            {
+                "heading": {
+                    "name": "xx xxxxxxxxxx"
+                },
+                "items": [
+                    {
+                        "name": "xxx",
+                        "href": "#",
+                        "index": 0
+                    },
+                    {
+                        "name": "xxxxxxxxxx",
+                        "href": "#",
+                        "index": 1
+                    },
+                    {
+                        "name": "xxxxx xxxx xxx xx",
+                        "href": "#",
+                        "index": 2
+                    },
+                    {
+                        "name": "xxxxx",
+                        "href": "#",
+                        "index": 3
+                    },
+                    {
+                        "name": "xxxxxxx xxxxxxx",
+                        "href": "#",
+                        "index": 4
+                    },
+                    {
+                        "name": "xxxx xxxx",
+                        "href": "#",
+                        "index": 5
+                    },
+                    {
+                        "name": "xxxxxxxxxxx",
+                        "href": "#",
+                        "index": 6
+                    }
+                ]
+            },
+            {
+                "items": [
+                    {
+                        "name": "xx xx",
+                        "href": "#",
+                        "variation": "secondary",
+                        "divide": true,
+                        "index": 0
+                    },
+                    {
+                        "name": "xxxxxxxxx",
+                        "href": "#",
+                        "variation": "secondary",
+                        "index": 1
+                    },
+                    {
+                        "name": "xxxxxxx xxxxx",
+                        "href": "#",
+                        "variation": "secondary",
+                        "index": 2
+                    }
+                ]
+            }
+        ],
+        "editions": {
+            "current": {
+                "name": "xx",
+                "id": "uk"
+            },
+            "others": [
+                {
+                    "name": "xxxxxxxxxxxxx",
+                    "id": "international"
+                }
+            ]
+        },
+        "user": {
+            "isSignedIn": false,
+            "name": "xxxxxx xxxx"
+        }
+    },
+    "subnav": true,
+    "currentNav": {
+        "name": "xx x xxxxxx",
+        "selected": true,
+        "ancestors": [
+            {
+                "name": "xxxxx",
+                "href": "#"
+            }
+        ],
+        "children": [
+            {
+                "name": "xx xxxxxxx",
+                "href": "#"
+            },
+            {
+                "name": "xx xxxxxxxx x xxxxxx",
+                "href": "#"
+            },
+            {
+                "name": "xx xxxxxxxxx",
+                "href": "#"
+            }
+        ],
+        "childrenRight": [
+            {
+                "name": "xxxx xxx",
+                "href": "#"
+            }
+        ]
+    }
+}

--- a/demos/src/subnav.mustache
+++ b/demos/src/subnav.mustache
@@ -73,6 +73,18 @@
 							</li>
 							{{/currentNav.children}}
 						</ul>
+
+						{{#currentNav.childrenRight.length}}
+						<ul class="o-header__subnav-list o-header__subnav-list--children o-header__subnav-list--right" aria-label="Actions">
+							{{#currentNav.childrenRight}}
+							<li class="o-header__subnav-item">
+								<a class="o-header__subnav-link" href="{{href}}" {{#selected}}aria-current="page" aria-label="Current page"{{/selected}}>
+									{{name}}
+								</a>
+							</li>
+							{{/currentNav.childrenRight}}
+						</ul>
+						{{/currentNav.childrenRight.length}}
 					</div>
 				</div>
 				<button class="o-header__subnav-button o-header__subnav-button--left" aria-hidden="true" disabled></button>

--- a/origami.json
+++ b/origami.json
@@ -58,6 +58,13 @@
 			"description": "Use the Origami Navigation Service to populate o-header with real navigation data. See the readme for more details."
 		},
 		{
+			"name": "subnav-right-aligned",
+			"title": "Header with subnav and right aligned items",
+			"data": "demos/src/subnav-right-align.json",
+			"template": "demos/src/subnav.mustache",
+			"description": "The subnav may have right aligned actions, for example to sign out of an admin area. Use the Origami Navigation Service to populate o-header with real navigation data. See the readme for more details."
+		},
+		{
 			"name": "simple-header",
 			"title": "Simple header",
 			"data": "demos/src/header.json",

--- a/src/scss/features/_subnav.scss
+++ b/src/scss/features/_subnav.scss
@@ -36,6 +36,8 @@
 	}
 
 	.o-header__subnav-content {
+		// Use flexbox to support right aligned subnav children
+		display: flex;
 		white-space: nowrap;
 		margin-left: $_o-header-sub-header-focus-margin;
 		margin-right: $_o-header-sub-header-focus-margin;
@@ -50,7 +52,7 @@
 		// to avoid positioning subnavs relative. This is so absolute children of the subnav are
 		// positioned relative to their closest positioned ancestor `o-header__container`.
 		// An example benefit is o-tooltip support against sub nav items.
-		& + & .o-header__subnav-item {
+		& + &:not(.o-header__subnav-list--right) .o-header__subnav-item {
 			&:first-child {
 				@include _oHeaderItemSeparatorContent();
 				&:before {
@@ -75,7 +77,7 @@
 			padding-left: 16px;
 		}
 
-		&:first-child {
+		.o-header__subnav-list--children:not(.o-header__subnav-list--right) &:first-child {
 			// align left side correctly
 			padding-left: 0;
 		}
@@ -94,6 +96,12 @@
 			}
 		}
 	}
+
+
+	.o-header__subnav-list--children.o-header__subnav-list--right {
+		margin-left: auto;
+	}
+
 
 	.o-header__subnav-link {
 		@include _oHeaderLink;


### PR DESCRIPTION
Closes: https://github.com/Financial-Times/o-header/issues/376

**ready for review, do not merge for now:** I'd like to [discuss with Alex first](https://github.com/Financial-Times/fticons/pull/102#issuecomment-685695102)

E.g. to right align a "sign out" item on an account page:

![Screenshot 2020-09-02 at 10 38 22](https://user-images.githubusercontent.com/10405691/91987371-dddc5a00-ed25-11ea-9ab5-3c90f565a51c.png)
![Screenshot 2020-09-02 at 10 38 31](https://user-images.githubusercontent.com/10405691/91987373-df0d8700-ed25-11ea-8304-81c8764f3a30.png)
![Screenshot 2020-09-02 at 10 38 36](https://user-images.githubusercontent.com/10405691/91987378-e03eb400-ed25-11ea-908d-0593bcb973d3.png)
![Screenshot 2020-09-02 at 10 38 44](https://user-images.githubusercontent.com/10405691/91987379-e03eb400-ed25-11ea-842b-58816dca7021.png)
