### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import Header from './src/js/header';
+import Header from './src/js/header.js';
 
 const constructAll = () => {
 	Header.init();

--- a/src/js/header.js
+++ b/src/js/header.js
@@ -1,8 +1,8 @@
-import search from './search';
-import mega from './mega';
-import drawer from './drawer';
-import subnav from './subnav';
-import sticky from './sticky';
+import search from './search.js';
+import mega from './mega.js';
+import drawer from './drawer.js';
+import subnav from './subnav.js';
+import sticky from './sticky.js';
 
 class Header {
 

--- a/test/autoinitialisation.test.js
+++ b/test/autoinitialisation.test.js
@@ -2,7 +2,7 @@
 /* global proclaim sinon */
 
 import fixtures from './helpers/fixtures.js';
-import Header from '../main.js.js';
+import Header from '../main.js';
 
 let pcfEl;
 

--- a/test/autoinitialisation.test.js
+++ b/test/autoinitialisation.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import fixtures from './helpers/fixtures';
-import Header from '../main.js';
+import fixtures from './helpers/fixtures.js';
+import Header from '../main.js.js';
 
 let pcfEl;
 

--- a/test/drawer.test.js
+++ b/test/drawer.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import Drawer from '../src/js/drawer';
+import Drawer from '../src/js/drawer.js';
 
 describe('Drawer instance', () => {
 

--- a/test/header.test.js
+++ b/test/header.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import Header from '../src/js/header';
+import Header from '../src/js/header.js';
 
 describe('Header API', () => {
 	it('is defined', () => {

--- a/test/mega.test.js
+++ b/test/mega.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import mega from '../src/js/mega';
+import mega from '../src/js/mega.js';
 
 function dispatch (target, type) {
 	target.dispatchEvent(new Event(type, { bubbles: true }));


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing