### PR TITLE
Correct core and enhanced experiences in local demos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ E.g. To get all of the CSS needed for the FT homepage you would call:
 
 ## Browser Support
 
-We use the [standard](https://origami.ft.com/docs/components/compatibility/#core--enhanced-experiences) `o--if-js` and `o--if-no-js` classes to hide elements in enhanced and core experience respectively
+To use `o-header` setup a [core and enhanced experience](https://origami.ft.com/docs/components/compatibility/#core--enhanced-experiences) within your project. `o-header` depends on the `o--if-js` and `o--if-no-js` classes.
 
 ## Migration guide
 

--- a/demos/src/main.js
+++ b/demos/src/main.js
@@ -1,7 +1,23 @@
 import '../../main.js';
 
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', setupDemo);
 
+document.onreadystatechange = function () {
+	if (document.readyState === 'complete') {
+		setupDemo();
+	} else if (document.readyState === 'interactive' && !document.attachEvent) {
+		setupDemo();
+	}
+};
+
+if (document.readyState === 'complete') {
+	setupDemo();
+} else if (document.readyState === 'interactive' && !document.attachEvent) {
+	setupDemo();
+}
+
+
+function setupDemo() {
 	if (document.documentElement.classList.contains('demo-sticky')) {
 		const p = document.createElement('p');
 		p.className = 'demo-sticky-message demo-sticky-message--';
@@ -19,4 +35,4 @@ document.addEventListener('DOMContentLoaded', function() {
 
 	document.documentElement.className = document.documentElement.className.replace('core', 'enhanced');
 	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
-});
+}

--- a/demos/src/main.scss
+++ b/demos/src/main.scss
@@ -61,3 +61,12 @@ body {
 	background-color: rgba(0, 0, 0, 0.2);
 	height: 60px;
 }
+
+// Components do not usually depend on these classes
+// since they are not part of the Origami component specification.
+// Instead consider removing an o-header specific class with
+// JavaScript in the future to indicate a core or enhances experience.
+.core .o--if-js,
+.enhanced .o--if-no-js {
+	display: none !important; //stylelint-disable-line declaration-no-important
+}


### PR DESCRIPTION
Demos have been broken locally since we decided to
remove classes injected by origami-build-tools.

We decided that going forward each component should
handle the core experience themselves so users have
less to setup, and components do not break if users
do not include the core/enhanced CSS.

https://github.com/Financial-Times/origami-build-tools/pull/814#issuecomment-646634393