### PR TITLE
Update markup of the editions switcher in the drawer.

### DIFF
--- a/demos/src/deprecated-editions-drawer.mustache
+++ b/demos/src/deprecated-editions-drawer.mustache
@@ -129,20 +129,18 @@
 			<button type="button" class="o-header__drawer-tools-close" aria-controls="o-header-drawer" title="Close drawer menu">
 				<span class="o-header__visually-hidden">Close drawer menu</span>
 			</button>
-			{{#editions}}
-			<p class="o-header__drawer-current-edition">{{editions.current.name}} Edition</p>
-			{{/editions}}
+            {{! current edition is not here in the deprecated markup }}
 		</div>
 
+        {{! the current and alternate editions are listed here in the deprecated markup }}
 		{{#editions}}
-		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
-			<ul class="o-header__drawer-menu-list">
-				{{#editions.others}}
-				<li class="o-header__drawer-menu-item"></li>
-					<a class="o-header__drawer-menu-link" href="/?edition={{id}}">Switch to {{name}} Edition</a>
-				</li>
-				{{/editions.others}}
-			</ul>
+		<nav class="o-header__drawer-editions" aria-label="Edition switcher">
+			{{#editions.current}}
+			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-current="page">{{name}} Edition</a>
+			{{/editions.current}}
+			{{#editions.others}}
+			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}">{{name}} Edition</a>
+			{{/editions.others}}
 		</nav>
 		{{/editions}}
 

--- a/demos/src/grid-demo.mustache
+++ b/demos/src/grid-demo.mustache
@@ -129,16 +129,20 @@
 			<button type="button" class="o-header__drawer-tools-close" aria-controls="o-header-drawer" title="Close drawer menu">
 				<span class="o-header__visually-hidden">Close drawer menu</span>
 			</button>
+			{{#editions}}
+			<p class="o-header__drawer-current-edition">{{editions.current.name}} Edition</p>
+			{{/editions}}
 		</div>
 
 		{{#editions}}
-		<nav class="o-header__drawer-editions" aria-label="Edition switcher">
-			{{#editions.current}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-current="page">{{name}} Edition</a>
-			{{/editions.current}}
-			{{#editions.others}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}">{{name}} Edition</a>
-			{{/editions.others}}
+		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
+			<ul class="o-header__drawer-menu-list">
+				{{#editions.others}}
+				<li class="o-header__drawer-menu-item"></li>
+					<a class="o-header__drawer-menu-link" href="/?edition={{id}}">Switch to {{name}} Edition</a>
+				</li>
+				{{/editions.others}}
+			</ul>
 		</nav>
 		{{/editions}}
 

--- a/demos/src/header.json
+++ b/demos/src/header.json
@@ -450,12 +450,12 @@
         ],
         "editions": {
             "current": {
-                "name": "xx",
+                "name": "UK",
                 "id": "uk"
             },
             "others": [
                 {
-                    "name": "xxxxxxxxxxxxx",
+                    "name": "International",
                     "id": "international"
                 }
             ]

--- a/demos/src/mega-menu.json
+++ b/demos/src/mega-menu.json
@@ -845,12 +845,12 @@
         ],
         "editions": {
             "current": {
-                "name": "xx",
+                "name": "UK",
                 "id": "uk"
             },
             "others": [
                 {
-                    "name": "xxxxxxxxxxxxx",
+                    "name": "International",
                     "id": "international"
                 }
             ]

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -129,16 +129,20 @@
 			<button type="button" class="o-header__drawer-tools-close" aria-controls="o-header-drawer" title="Close drawer menu">
 				<span class="o-header__visually-hidden">Close drawer menu</span>
 			</button>
+			{{#editions}}
+			<p class="o-header__drawer-current-edition">{{editions.current.name}} Edition</p>
+			{{/editions}}
 		</div>
 
 		{{#editions}}
-		<nav class="o-header__drawer-editions" aria-label="Edition switcher">
-			{{#editions.current}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-current="page">{{name}} Edition</a>
-			{{/editions.current}}
-			{{#editions.others}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}">{{name}} Edition</a>
-			{{/editions.others}}
+		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
+			<ul class="o-header__drawer-menu-list">
+				{{#editions.others}}
+				<li class="o-header__drawer-menu-item"></li>
+					<a class="o-header__drawer-menu-link" href="/?edition={{id}}">Switch to {{name}} Edition</a>
+				</li>
+				{{/editions.others}}
+			</ul>
 		</nav>
 		{{/editions}}
 

--- a/demos/src/simple-header.mustache
+++ b/demos/src/simple-header.mustache
@@ -61,16 +61,20 @@
 			<button type="button" class="o-header__drawer-tools-close" aria-controls="o-header-drawer" title="Close drawer menu">
 				<span class="o-header__visually-hidden">Close drawer menu</span>
 			</button>
+			{{#editions}}
+			<p class="o-header__drawer-current-edition">{{editions.current.name}} Edition</p>
+			{{/editions}}
 		</div>
 
 		{{#editions}}
-		<nav class="o-header__drawer-editions" aria-label="Edition switcher">
-			{{#editions.current}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-current="page">{{name}} Edition</a>
-			{{/editions.current}}
-			{{#editions.others}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}">{{name}} Edition</a>
-			{{/editions.others}}
+		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
+			<ul class="o-header__drawer-menu-list">
+				{{#editions.others}}
+				<li class="o-header__drawer-menu-item"></li>
+					<a class="o-header__drawer-menu-link" href="/?edition={{id}}">Switch to {{name}} Edition</a>
+				</li>
+				{{/editions.others}}
+			</ul>
 		</nav>
 		{{/editions}}
 

--- a/demos/src/sticky-header.mustache
+++ b/demos/src/sticky-header.mustache
@@ -92,16 +92,20 @@
 			<button type="button" class="o-header__drawer-tools-close" aria-controls="o-header-drawer" title="Close drawer menu">
 				<span class="o-header__visually-hidden">Close drawer menu</span>
 			</button>
+			{{#editions}}
+			<p class="o-header__drawer-current-edition">{{editions.current.name}} Edition</p>
+			{{/editions}}
 		</div>
 
 		{{#editions}}
-		<nav class="o-header__drawer-editions" aria-label="Edition switcher">
-			{{#editions.current}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-current="page">{{name}} Edition</a>
-			{{/editions.current}}
-			{{#editions.others}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}">{{name}} Edition</a>
-			{{/editions.others}}
+		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
+			<ul class="o-header__drawer-menu-list">
+				{{#editions.others}}
+				<li class="o-header__drawer-menu-item"></li>
+					<a class="o-header__drawer-menu-link" href="/?edition={{id}}">Switch to {{name}} Edition</a>
+				</li>
+				{{/editions.others}}
+			</ul>
 		</nav>
 		{{/editions}}
 

--- a/demos/src/subbrand.json
+++ b/demos/src/subbrand.json
@@ -439,12 +439,12 @@
         ],
         "editions": {
             "current": {
-                "name": "xx",
+                "name": "UK",
                 "id": "uk"
             },
             "others": [
                 {
-                    "name": "xxxxxxxxxxxxx",
+                    "name": "International",
                     "id": "international"
                 }
             ]

--- a/demos/src/subbrand.mustache
+++ b/demos/src/subbrand.mustache
@@ -57,16 +57,20 @@
 			<button type="button" class="o-header__drawer-tools-close" aria-controls="o-header-drawer" title="Close drawer menu">
 				<span class="o-header__visually-hidden">Close drawer menu</span>
 			</button>
+			{{#editions}}
+			<p class="o-header__drawer-current-edition">{{editions.current.name}} Edition</p>
+			{{/editions}}
 		</div>
 
 		{{#editions}}
-		<nav class="o-header__drawer-editions" aria-label="Edition switcher">
-			{{#editions.current}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-current="page">{{name}} Edition</a>
-			{{/editions.current}}
-			{{#editions.others}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}">{{name}} Edition</a>
-			{{/editions.others}}
+		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
+			<ul class="o-header__drawer-menu-list">
+				{{#editions.others}}
+				<li class="o-header__drawer-menu-item"></li>
+					<a class="o-header__drawer-menu-link" href="/?edition={{id}}">Switch to {{name}} Edition</a>
+				</li>
+				{{/editions.others}}
+			</ul>
 		</nav>
 		{{/editions}}
 

--- a/demos/src/subnav-right-align.json
+++ b/demos/src/subnav-right-align.json
@@ -450,12 +450,12 @@
         ],
         "editions": {
             "current": {
-                "name": "xx",
+                "name": "UK",
                 "id": "uk"
             },
             "others": [
                 {
-                    "name": "xxxxxxxxxxxxx",
+                    "name": "International",
                     "id": "international"
                 }
             ]

--- a/demos/src/transparent-header.mustache
+++ b/demos/src/transparent-header.mustache
@@ -132,16 +132,20 @@
 			<button type="button" class="o-header__drawer-tools-close" aria-controls="o-header-drawer" title="Close drawer menu">
 				<span class="o-header__visually-hidden">Close drawer menu</span>
 			</button>
+			{{#editions}}
+			<p class="o-header__drawer-current-edition">{{editions.current.name}} Edition</p>
+			{{/editions}}
 		</div>
 
 		{{#editions}}
-		<nav class="o-header__drawer-editions" aria-label="Edition switcher">
-			{{#editions.current}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}" aria-label="Current edition" aria-current="page">{{name}} Edition</a>
-			{{/editions.current}}
-			{{#editions.others}}
-			<a class="o-header__drawer-editions-link" href="/{{id}}?edition={{id}}">{{name}} Edition</a>
-			{{/editions.others}}
+		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
+			<ul class="o-header__drawer-menu-list">
+				{{#editions.others}}
+				<li class="o-header__drawer-menu-item"></li>
+					<a class="o-header__drawer-menu-link" href="/?edition={{id}}">Switch to {{name}} Edition</a>
+				</li>
+				{{/editions.others}}
+			</ul>
 		</nav>
 		{{/editions}}
 

--- a/origami.json
+++ b/origami.json
@@ -44,6 +44,14 @@
 			"description": "Use the Origami Navigation Service to populate o-header with real navigation data. See the readme for more details."
 		},
 		{
+			"name": "header-deprecated-editions-markup",
+			"title": "Header with deprecated editions markup in the drawer.",
+			"data": "demos/src/header.json",
+			"template": "demos/src/deprecated-editions-drawer.mustache",
+			"hidden": true,
+			"description": "This demo shows old editions markup in the drawer. This markup is deprecated and should be removed in the next major version."
+		},
+		{
 			"name": "mega-menu",
 			"title": "Mega menu",
 			"data": "demos/src/mega-menu.json",

--- a/src/scss/features/_drawer.scss
+++ b/src/scss/features/_drawer.scss
@@ -112,10 +112,18 @@
 	//
 	// Editions
 	//
+	.o-header__drawer-current-edition {
+		@include oTypographySans($scale: -1);
+		color: oColorsByName('black-60');
+		margin: 0.5em 0;
+	}
+
+	// @deprecated - Remove `o-header__drawer-editions` in the next major
 	.o-header__drawer-editions {
 		padding: 0 $_o-header-drawer-padding-x;
 	}
 
+	// @deprecated - Remove `o-header__drawer-editions-link` in the next major
 	.o-header__drawer-editions-link {
 		color: _oHeaderGet('drawer-editions-link');
 		display: inline-block;


### PR DESCRIPTION
- Updates markup to reflect most ft.com projects.
- Includes some styles currently defined in pagekit.
- Deprecates existing editions switcher markup as some
projects may still use it.

Pagekit styles: https://github.com/Financial-Times/dotcom-page-kit/blob/a25325d2e534895ac386c508af43a50e9ccf4b56/packages/dotcom-ui-header/src/header.scss
Fixes: https://github.com/Financial-Times/o-header/issues/399

before/after
![Screenshot 2020-09-22 at 11 50 24](https://user-images.githubusercontent.com/10405691/93876363-a5012680-fcce-11ea-9cdb-5209de6acbb4.png)
![Screenshot 2020-09-22 at 11 50 34](https://user-images.githubusercontent.com/10405691/93876366-a6325380-fcce-11ea-8c7d-9a81750c14d5.png)
