### PR TITLE
Update drawer search sort order.

### DIFF
--- a/demos/src/deprecated-markup.mustache
+++ b/demos/src/deprecated-markup.mustache
@@ -144,6 +144,7 @@
 		</nav>
 		{{/editions}}
 
+		{{! the search element used to be below the editions element }}
 		<div class="o-header__drawer-search">
 			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
 				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>

--- a/demos/src/grid-demo.mustache
+++ b/demos/src/grid-demo.mustache
@@ -134,6 +134,16 @@
 			{{/editions}}
 		</div>
 
+		<div class="o-header__drawer-search">
+			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
+				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
+				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the FT">
+				<button class="o-header__drawer-search-submit" type="submit">
+					<span class="o-header__visually-hidden">Search</span>
+				</button>
+			</form>
+		</div>
+
 		{{#editions}}
 		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
 			<ul class="o-header__drawer-menu-list">
@@ -145,16 +155,6 @@
 			</ul>
 		</nav>
 		{{/editions}}
-
-		<div class="o-header__drawer-search">
-			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
-				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
-				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the FT">
-				<button class="o-header__drawer-search-submit" type="submit">
-					<span class="o-header__visually-hidden">Search</span>
-				</button>
-			</form>
-		</div>
 
 		<nav class="o-header__drawer-menu o-header__drawer-menu--primary">
 			<ul class="o-header__drawer-menu-list">

--- a/demos/src/header.mustache
+++ b/demos/src/header.mustache
@@ -134,6 +134,16 @@
 			{{/editions}}
 		</div>
 
+		<div class="o-header__drawer-search">
+			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
+				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
+				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the FT">
+				<button class="o-header__drawer-search-submit" type="submit">
+					<span class="o-header__visually-hidden">Search</span>
+				</button>
+			</form>
+		</div>
+
 		{{#editions}}
 		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
 			<ul class="o-header__drawer-menu-list">
@@ -145,16 +155,6 @@
 			</ul>
 		</nav>
 		{{/editions}}
-
-		<div class="o-header__drawer-search">
-			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
-				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
-				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the FT">
-				<button class="o-header__drawer-search-submit" type="submit">
-					<span class="o-header__visually-hidden">Search</span>
-				</button>
-			</form>
-		</div>
 
 		<nav class="o-header__drawer-menu o-header__drawer-menu--primary">
 			<ul class="o-header__drawer-menu-list">

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -134,6 +134,16 @@
 			{{/editions}}
 		</div>
 
+		<div class="o-header__drawer-search">
+			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
+				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
+				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the FT">
+				<button class="o-header__drawer-search-submit" type="submit">
+					<span class="o-header__visually-hidden">Search</span>
+				</button>
+			</form>
+		</div>
+
 		{{#editions}}
 		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
 			<ul class="o-header__drawer-menu-list">
@@ -145,16 +155,6 @@
 			</ul>
 		</nav>
 		{{/editions}}
-
-		<div class="o-header__drawer-search">
-			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
-				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
-				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the FT">
-				<button class="o-header__drawer-search-submit" type="submit">
-					<span class="o-header__visually-hidden">Search</span>
-				</button>
-			</form>
-		</div>
 
 		<nav class="o-header__drawer-menu o-header__drawer-menu--primary">
 			<ul class="o-header__drawer-menu-list">

--- a/demos/src/simple-header.mustache
+++ b/demos/src/simple-header.mustache
@@ -66,6 +66,16 @@
 			{{/editions}}
 		</div>
 
+		<div class="o-header__drawer-search">
+			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
+				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
+				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the FT">
+				<button class="o-header__drawer-search-submit" type="submit">
+					<span class="o-header__visually-hidden">Search</span>
+				</button>
+			</form>
+		</div>
+
 		{{#editions}}
 		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
 			<ul class="o-header__drawer-menu-list">
@@ -77,16 +87,6 @@
 			</ul>
 		</nav>
 		{{/editions}}
-
-		<div class="o-header__drawer-search">
-			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
-				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
-				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the FT">
-				<button class="o-header__drawer-search-submit" type="submit">
-					<span class="o-header__visually-hidden">Search</span>
-				</button>
-			</form>
-		</div>
 
 		<nav class="o-header__drawer-menu o-header__drawer-menu--primary">
 			<ul class="o-header__drawer-menu-list">

--- a/demos/src/sticky-header.mustache
+++ b/demos/src/sticky-header.mustache
@@ -97,6 +97,16 @@
 			{{/editions}}
 		</div>
 
+		<div class="o-header__drawer-search">
+			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
+				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
+				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the FT">
+				<button class="o-header__drawer-search-submit" type="submit">
+					<span class="o-header__visually-hidden">Search</span>
+				</button>
+			</form>
+		</div>
+
 		{{#editions}}
 		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
 			<ul class="o-header__drawer-menu-list">
@@ -108,16 +118,6 @@
 			</ul>
 		</nav>
 		{{/editions}}
-
-		<div class="o-header__drawer-search">
-			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
-				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
-				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the FT">
-				<button class="o-header__drawer-search-submit" type="submit">
-					<span class="o-header__visually-hidden">Search</span>
-				</button>
-			</form>
-		</div>
 
 		<nav class="o-header__drawer-menu o-header__drawer-menu--primary">
 			<ul class="o-header__drawer-menu-list">

--- a/demos/src/subbrand.mustache
+++ b/demos/src/subbrand.mustache
@@ -62,6 +62,16 @@
 			{{/editions}}
 		</div>
 
+		<div class="o-header__drawer-search">
+			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
+				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
+				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the FT">
+				<button class="o-header__drawer-search-submit" type="submit">
+					<span class="o-header__visually-hidden">Search</span>
+				</button>
+			</form>
+		</div>
+
 		{{#editions}}
 		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
 			<ul class="o-header__drawer-menu-list">
@@ -73,16 +83,6 @@
 			</ul>
 		</nav>
 		{{/editions}}
-
-		<div class="o-header__drawer-search">
-			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
-				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
-				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the FT">
-				<button class="o-header__drawer-search-submit" type="submit">
-					<span class="o-header__visually-hidden">Search</span>
-				</button>
-			</form>
-		</div>
 
 		<nav class="o-header__drawer-menu o-header__drawer-menu--primary">
 			<ul class="o-header__drawer-menu-list">

--- a/demos/src/transparent-header.mustache
+++ b/demos/src/transparent-header.mustache
@@ -137,6 +137,16 @@
 			{{/editions}}
 		</div>
 
+		<div class="o-header__drawer-search">
+			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
+				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
+				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the FT">
+				<button class="o-header__drawer-search-submit" type="submit">
+					<span class="o-header__visually-hidden">Search</span>
+				</button>
+			</form>
+		</div>
+
 		{{#editions}}
 		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
 			<ul class="o-header__drawer-menu-list">
@@ -148,16 +158,6 @@
 			</ul>
 		</nav>
 		{{/editions}}
-
-		<div class="o-header__drawer-search">
-			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
-				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
-				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the FT">
-				<button class="o-header__drawer-search-submit" type="submit">
-					<span class="o-header__visually-hidden">Search</span>
-				</button>
-			</form>
-		</div>
 
 		<nav class="o-header__drawer-menu o-header__drawer-menu--primary">
 			<ul class="o-header__drawer-menu-list">

--- a/origami.json
+++ b/origami.json
@@ -44,12 +44,12 @@
 			"description": "Use the Origami Navigation Service to populate o-header with real navigation data. See the readme for more details."
 		},
 		{
-			"name": "header-deprecated-editions-markup",
-			"title": "Header with deprecated editions markup in the drawer.",
+			"name": "header-deprecated-markup",
+			"title": "Header with deprecated markup in the drawer.",
 			"data": "demos/src/header.json",
-			"template": "demos/src/deprecated-editions-drawer.mustache",
+			"template": "demos/src/deprecated-markup.mustache",
 			"hidden": true,
-			"description": "This demo shows old editions markup in the drawer. This markup is deprecated and should be removed in the next major version."
+			"description": "This demo shows outdated drawer markup. This includes previous edition switcher markup and a different element order, where the search element is first before the edition switcher. This markup is deprecated and should be removed in the next major version."
 		},
 		{
 			"name": "mega-menu",

--- a/src/scss/features/_drawer.scss
+++ b/src/scss/features/_drawer.scss
@@ -47,6 +47,9 @@
 	}
 
 	.o-header__drawer-inner {
+		display: flex;
+		flex-direction: column;
+
 		[data-o-header-drawer--js] & {
 			height: 100%;
 			overflow-y: auto;
@@ -74,7 +77,7 @@
 	// Tools
 	//
 	.o-header__drawer-tools {
-		overflow: hidden;
+		order: -1; // @deprecated, remove in the next major. For deprecated markup move order to beginning, first before search.
 		padding: ($_o-header-drawer-padding-y * 1.5) 0 $_o-header-drawer-padding-y $_o-header-drawer-padding-x;
 		background-color: _oHeaderGet('drawer-tools-background');
 		color: _oHeaderGet('drawer-tools-text');
@@ -149,6 +152,8 @@
 	// Search
 	//
 	.o-header__drawer-search {
+		order: -1;  // @deprecated, remove in the next major. For deprecated markup move search to next after the drawer tools
+		border-top: 2px solid oColorsByName('black-10');
 		padding: $_o-header-drawer-padding-y $_o-header-drawer-padding-x;
 
 		@include oGridRespondTo('L') {


### PR DESCRIPTION
Places the drawer search below the edition switcher.
Matches majority of ft.com existing uses.
Uses CSS grid to visually reorder the search field
for projects which use the old source order -- semantically,
both order feel appropriate.

Before/after
![Screenshot 2020-09-22 at 14 45 55](https://user-images.githubusercontent.com/10405691/93890867-b2281080-fce2-11ea-8d33-9fb9d5042bec.png)

![Screenshot 2020-09-22 at 14 45 57](https://user-images.githubusercontent.com/10405691/93890872-b3f1d400-fce2-11ea-8082-34545b9f5002.png)