### PR TITLE
Do not use the `order` property to arrange the drawer.

### DIFF
--- a/src/scss/features/_drawer.scss
+++ b/src/scss/features/_drawer.scss
@@ -47,9 +47,6 @@
 	}
 
 	.o-header__drawer-inner {
-		display: flex;
-		flex-direction: column;
-
 		[data-o-header-drawer--js] & {
 			height: 100%;
 			overflow-y: auto;
@@ -77,7 +74,7 @@
 	// Tools
 	//
 	.o-header__drawer-tools {
-		order: -1; // @deprecated, remove in the next major. For deprecated markup move order to beginning, first before search.
+		overflow: hidden;
 		padding: ($_o-header-drawer-padding-y * 1.5) 0 $_o-header-drawer-padding-y $_o-header-drawer-padding-x;
 		background-color: _oHeaderGet('drawer-tools-background');
 		color: _oHeaderGet('drawer-tools-text');
@@ -152,7 +149,6 @@
 	// Search
 	//
 	.o-header__drawer-search {
-		order: -1;  // @deprecated, remove in the next major. For deprecated markup move search to next after the drawer tools
 		border-top: 2px solid oColorsByName('black-10');
 		padding: $_o-header-drawer-padding-y $_o-header-drawer-padding-x;
 


### PR DESCRIPTION
This leads to an odd tab order.
The deprecated markup renders in an acceptable way without.

This is a partial revert of:

latest markup, used by pagekit and many ft.com projects
![Screenshot 2020-09-22 at 16 49 29](https://user-images.githubusercontent.com/10405691/93906262-e48e3980-fcf3-11ea-8a1a-37e7b86a7d1a.png)

deprecated markup:
![Screenshot 2020-09-22 at 16 49 45](https://user-images.githubusercontent.com/10405691/93906309-f2dc5580-fcf3-11ea-9e60-c2499a0579f2.png)
