### PR TITLE
Normalise drawer search input style

### DIFF
--- a/src/scss/features/_drawer.scss
+++ b/src/scss/features/_drawer.scss
@@ -164,7 +164,6 @@
 	.o-header__drawer-search-term,
 	.o-header__drawer-search-submit {
 		box-sizing: border-box;
-		// ಥ_ಥ
 		height: 32px;
 		padding: 8px ($_o-header-drawer-padding-x / 2);
 		border: 1px solid;
@@ -176,6 +175,15 @@
 		background-color: _oHeaderGet('drawer-search-term-background');
 		border-color: _oHeaderGet('drawer-search-term-border');
 		flex-grow: 1;
+		// normalize
+		appearance: none;
+		background: white;
+		border-style: solid;
+		box-shadow: none;
+		border-radius: 0;
+		// margin copied from o-forms since introducing a new dependency would
+		// be a breaking change, this colour could go in o-colors as a usecase
+		border: 1px solid oColorsByName('black-50');
 
 		&:focus { //currently overriden by o-normalise
 			border-color: _oHeaderGet('drawer-search-term-highlight-border');

--- a/src/scss/features/_search.scss
+++ b/src/scss/features/_search.scss
@@ -27,11 +27,12 @@
 		padding: 0 8px;
 		vertical-align: middle;
 		// normalize
+		appearance: none;
 		background: white;
 		border-style: solid;
 		border-color: transparent;
-		// oh, webkit...
 		box-shadow: none;
+		border-radius: 0;
 		// fill!
 		min-width: 50%;
 		flex-grow: 1;


### PR DESCRIPTION
before safari shows a default style including radius and drop shadow:
![Screenshot 2020-09-22 at 17 54 08](https://user-images.githubusercontent.com/10405691/93913339-dbee3100-fcfc-11ea-8523-54b1ac6b6993.png)

that is gone now:
![Screenshot 2020-09-22 at 17 53 46](https://user-images.githubusercontent.com/10405691/93913389-edcfd400-fcfc-11ea-88bb-437e22222b4d.png)
