### PR TITLE
Improve search close button's readability

### DIFF
--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -22,6 +22,7 @@
 
 			search-border: oColorsByName('teal-40'),
 			search-background: oColorsByName('black-20'),
+			search-close: oColorsByName('black-80'),
 
 			mega-menu-background: oColorsByName('white-60'),
 

--- a/src/scss/features/_search.scss
+++ b/src/scss/features/_search.scss
@@ -54,10 +54,15 @@
 	}
 
 	.o-header__search-close {
-		@include oIconsContent('cross', white, $size: $_o-header-icon-size-large);
+		@include oIconsContent('cross', _oHeaderGet('search-close'), $size: $_o-header-icon-size-large);
 		border: 0;
 		margin-left: $_o-header-padding-x;
 		vertical-align: middle;
+		// Match the search button's hover/focus state.
+		&:hover,
+		&:focus {
+			opacity: 0.75;
+		}
 
 		@include oGridRespondTo($until: 'M') {
 			display: none;


### PR DESCRIPTION
At the moment the white against grey has a contrast ratio of 1.76:1.

For [non-text contrast requirement](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html) we need a ratio of at least 3:1.

My proposal is to make this close button consistent with the main drawer menu's close button which will make it easier to see.

It will also increase the contrast ratio to 7.43:1.

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/98798145-6e5da780-2405-11eb-88f5-9d82bf4f5588.png) | ![](https://user-images.githubusercontent.com/2445413/98798164-74538880-2405-11eb-9d56-c38c98023260.png) |
